### PR TITLE
QA-9309 : Allow special characters (including ":") in VFS provider.

### DIFF
--- a/vfs/src/main/resources/META-INF/providers.xml
+++ b/vfs/src/main/resources/META-INF/providers.xml
@@ -1,0 +1,84 @@
+<providers>
+    <default-provider class-name="org.apache.commons.vfs2.provider.url.UrlFileProvider">
+    </default-provider>
+    <provider class-name="org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider">
+        <scheme name="file"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.zip.ZipFileProvider">
+        <scheme name="zip"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tar"/>
+        <if-available class-name="org.apache.commons.vfs2.provider.tar.TarInputStream"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.bzip2.Bzip2FileProvider">
+        <scheme name="bz2"/>
+        <if-available class-name="org.apache.commons.vfs2.provider.bzip2.CBZip2InputStream"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.gzip.GzipFileProvider">
+        <scheme name="gz"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.jar.JarFileProvider">
+        <scheme name="jar"/>
+        <scheme name="sar"/>
+        <scheme name="ear"/>
+        <scheme name="par"/>
+        <scheme name="ejb3"/>
+        <scheme name="war"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.temp.TemporaryFileProvider">
+        <scheme name="tmp"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftp.FtpFileProvider">
+        <scheme name="ftp"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftps.FtpsFileProvider">
+        <scheme name="ftps"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.http.HttpFileProvider">
+        <scheme name="http"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.https.HttpsFileProvider">
+        <scheme name="https"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.sftp.SftpFileProvider">
+        <scheme name="sftp"/>
+        <if-available class-name="javax.crypto.Cipher"/>
+        <if-available class-name="com.jcraft.jsch.JSch"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.res.ResourceFileProvider">
+        <scheme name="res"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.webdav.WebdavFileProvider">
+        <scheme name="webdav"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.DavMethod"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tgz"/>
+        <if-available scheme="gz"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tbz2"/>
+        <if-available scheme="bz2"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ram.RamFileProvider">
+        <scheme name="ram"/>
+    </provider>
+    <extension-map extension="zip" scheme="zip"/>
+    <extension-map extension="tar" scheme="tar"/>
+    <mime-type-map mime-type="application/zip" scheme="zip"/>
+    <mime-type-map mime-type="application/x-tar" scheme="tar"/>
+    <mime-type-map mime-type="application/x-gzip" scheme="gz"/>
+    <extension-map extension="jar" scheme="jar"/>
+    <extension-map extension="bz2" scheme="bz2"/>
+    <extension-map extension="gz" scheme="gz"/>
+    <extension-map extension="tgz" scheme="tar"/>
+    <extension-map extension="tbz2" scheme="tar"/>
+</providers>


### PR DESCRIPTION
Two problems are solved : 
* The VFS does not handle files with ":" (cf https://issues.apache.org/jira/browse/VFS-398 )
* We don't escape the ExternalData in the VFS provider