### PR TITLE
QA-9309 : Allow special character ":", "[", "]" in VFS provider.

### DIFF
--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 
 /**
  * VFS Implementation of ExternalDataSource
@@ -76,7 +77,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private static final String JCR_CONTENT_SUFFIX = "/" + Constants.JCR_CONTENT;
     private FileObject root;
     private String rootPath;
-    private FileSystemManager manager;
+    private StandardFileSystemManager manager;
 
     /**
      * Defines the root point of the DataSource
@@ -85,7 +86,16 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      */
     public void setRoot(String rootUri) {
         try {
-            manager = VFS.getManager();
+            manager = new StandardFileSystemManager() {
+                @Override
+                public FileName resolveName(final FileName base, final String name, final NameScope scope)
+                        throws FileSystemException {
+                    return super.resolveName(base, escape(name), scope);
+                }
+
+            };
+            manager.setConfiguration(VFSDataSource.class.getResource("/META-INF/providers.xml"));
+            manager.init();
             root = manager.resolveFile(rootUri);
             rootPath = root.getName().getPath();
         } catch (Exception e) {
@@ -170,8 +180,9 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
 
     public FileObject getFile(String path) throws FileSystemException {
-        return (path == null || path.length() == 0 || path.equals("/")) ? root : root
-                .resolveFile(path.charAt(0) == '/' ? path.substring(1) : path);
+        final String unescapedPath = unescape(path);
+        return (unescapedPath == null || unescapedPath.length() == 0 || unescapedPath.equals("/")) ? root : root
+                .resolveFile(unescapedPath.charAt(0) == '/' ? unescapedPath.substring(1) : unescapedPath);
     }
 
     public List<String> getChildren(String path) throws RepositoryException {
@@ -350,8 +361,9 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
+        String escapedPath = escape(path);
 
-        ExternalData result = new ExternalData(path, path, type, properties);
+        ExternalData result = new ExternalData(path, escapedPath, type, properties);
         result.setMixin(addedMixins);
         return result;
     }
@@ -367,8 +379,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         properties.put(Constants.JCR_MIMETYPE, new String[]{getContentType(content)});
 
         String path = content.getFile().getName().getPath().substring(rootPath.length());
-        String jcrContentPath = path + "/" + Constants.JCR_CONTENT;
-        ExternalData externalData = new ExternalData(jcrContentPath, jcrContentPath, Constants.JAHIANT_RESOURCE, properties);
+        String escapedPath = escape(path);
+        ExternalData externalData = new ExternalData(path + "/" + Constants.JCR_CONTENT, escapedPath + "/" + Constants.JCR_CONTENT, Constants.JAHIANT_RESOURCE, properties);
 
         Map<String, Binary[]> binaryProperties = new HashMap<String, Binary[]>(1);
         binaryProperties.put(Constants.JCR_DATA, new Binary[]{new VFSBinaryImpl(content)});
@@ -387,4 +399,20 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         }
         return s1;
     }
+    
+    private static String escape(String path){
+        if(path==null){
+            return path;
+        }
+        final String escapedPath =  path.replaceAll(":", "%3A").replaceAll("\\[", "%5B").replaceAll("\\]", "%5D");
+        return escapedPath;
+    }
+    
+    private static String unescape(String path){
+        if(path==null){
+            return path;
+        }
+        final String escapedPath =  path.replaceAll("%3A", ":").replaceAll("%5B", "[").replaceAll("%5D", "]");
+        return escapedPath;        
+    }    
 }

--- a/vfs/src/main/resources/META-INF/providers.xml
+++ b/vfs/src/main/resources/META-INF/providers.xml
@@ -1,0 +1,84 @@
+<providers>
+    <default-provider class-name="org.apache.commons.vfs2.provider.url.UrlFileProvider">
+    </default-provider>
+    <provider class-name="org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider">
+        <scheme name="file"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.zip.ZipFileProvider">
+        <scheme name="zip"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tar"/>
+        <if-available class-name="org.apache.commons.vfs2.provider.tar.TarInputStream"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.bzip2.Bzip2FileProvider">
+        <scheme name="bz2"/>
+        <if-available class-name="org.apache.commons.vfs2.provider.bzip2.CBZip2InputStream"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.gzip.GzipFileProvider">
+        <scheme name="gz"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.jar.JarFileProvider">
+        <scheme name="jar"/>
+        <scheme name="sar"/>
+        <scheme name="ear"/>
+        <scheme name="par"/>
+        <scheme name="ejb3"/>
+        <scheme name="war"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.temp.TemporaryFileProvider">
+        <scheme name="tmp"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftp.FtpFileProvider">
+        <scheme name="ftp"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ftps.FtpsFileProvider">
+        <scheme name="ftps"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.http.HttpFileProvider">
+        <scheme name="http"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.https.HttpsFileProvider">
+        <scheme name="https"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.sftp.SftpFileProvider">
+        <scheme name="sftp"/>
+        <if-available class-name="javax.crypto.Cipher"/>
+        <if-available class-name="com.jcraft.jsch.JSch"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.res.ResourceFileProvider">
+        <scheme name="res"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.webdav.WebdavFileProvider">
+        <scheme name="webdav"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.DavMethod"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tgz"/>
+        <if-available scheme="gz"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tbz2"/>
+        <if-available scheme="bz2"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="org.apache.commons.vfs2.provider.ram.RamFileProvider">
+        <scheme name="ram"/>
+    </provider>
+    <extension-map extension="zip" scheme="zip"/>
+    <extension-map extension="tar" scheme="tar"/>
+    <mime-type-map mime-type="application/zip" scheme="zip"/>
+    <mime-type-map mime-type="application/x-tar" scheme="tar"/>
+    <mime-type-map mime-type="application/x-gzip" scheme="gz"/>
+    <extension-map extension="jar" scheme="jar"/>
+    <extension-map extension="bz2" scheme="bz2"/>
+    <extension-map extension="gz" scheme="gz"/>
+    <extension-map extension="tgz" scheme="tar"/>
+    <extension-map extension="tbz2" scheme="tar"/>
+</providers>


### PR DESCRIPTION
- The VFS does not handle files with ":" (cf https://issues.apache.org/jira/browse/VFS-398 )
- We don't escape the characters ":", "[", "]" in the VFS provider
