### PR TITLE
BACKLOG-9282 Allow modules to implement ModulesSourceMonitor to monit…

### DIFF
--- a/modules-provider/src/main/java/org/jahia/modules/external/modules/osgi/ModulesSourceMonitor.java
+++ b/modules-provider/src/main/java/org/jahia/modules/external/modules/osgi/ModulesSourceMonitor.java
@@ -1,0 +1,10 @@
+package org.jahia.modules.external.modules.osgi;
+
+import org.apache.commons.vfs2.FileObject;
+
+import java.io.File;
+
+public interface ModulesSourceMonitor {
+    boolean canHandleFileType(FileObject filePath);
+    void handleFile(File file);
+}

--- a/modules-provider/src/main/resources/META-INF/spring/mod-external-provider-modules.xml
+++ b/modules-provider/src/main/resources/META-INF/spring/mod-external-provider-modules.xml
@@ -70,6 +70,9 @@
         <property name="jcrStoreService" ref="JCRStoreService" />
         <property name="modulesSourceSpringInitializer" ref="ModulesSourceSpringInitializer" />
         <property name="modulesImportExportHelper" ref="ModulesImportExportHelper" />
+        <property name="sourceMonitors">
+            <osgi:list interface="org.jahia.modules.external.modules.osgi.ModulesSourceMonitor" availability="optional"/>
+        </property>
     </bean>
 
     <bean id="ModulesSourceSpringInitializer" class="org.jahia.modules.external.modules.osgi.ModulesSourceSpringInitializer" factory-method="getInstance">


### PR DESCRIPTION
…or custom files.

Custom behaviour will be on top of existing behaviour. This is ideal to monitor new type of files like an SDL file to register new GraphQL API extensions point