### PR TITLE
QA-13986 Run code in callback with closable system session

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/events/EventServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/events/EventServiceImpl.java
@@ -84,14 +84,26 @@ public class EventServiceImpl implements EventService {
                 }
                 JCRObservationManager.addEvent(apiEvent, provider.getMountPoint(), "");
             }
-            jcrSessionWrapper.logout();
             return null;
         };
 
-        logger.debug("Processing API events for default");
-        JCRObservationManager.doWorkspaceWriteCall(JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, null, null), JCRObservationManager.API, callback);
-        logger.debug("Processing API events for live");
-        JCRObservationManager.doWorkspaceWriteCall(JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.LIVE_WORKSPACE, null, null), JCRObservationManager.API, callback);
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, null, new JCRCallback<Object>() {
+            @Override
+            public Object doInJCR(JCRSessionWrapper jcrSessionWrapper) throws RepositoryException {
+                logger.debug("Processing API events for default");
+                JCRObservationManager.doWorkspaceWriteCall(jcrSessionWrapper, JCRObservationManager.API, callback);
+                return null;
+            }
+        });
+
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.LIVE_WORKSPACE, null, new JCRCallback<Object>() {
+            @Override
+            public Object doInJCR(JCRSessionWrapper jcrSessionWrapper) throws RepositoryException {
+                logger.debug("Processing API events for live");
+                JCRObservationManager.doWorkspaceWriteCall(jcrSessionWrapper, JCRObservationManager.API, callback);
+                return null;
+            }
+        });
 
         logger.info("API events processed");
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13986

## Description

Executing doSendEvents call in a dedicated thread was keeping sessions open, logout did not work as current sessions are not logged out of because they can be shared. Suggested solution is to run code with closable system session in a given workspace to avoid persisting session objects after callback completes.