### PR TITLE
QA-14491: Ensure property.getType() does not return UNDEFINED

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/ExternalPropertyImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/ExternalPropertyImpl.java
@@ -257,7 +257,7 @@ public class ExternalPropertyImpl extends ExternalItemImpl implements Property {
     }
 
     public int getType() throws RepositoryException {
-        return getDefinition().getRequiredType();
+        return getSafePropertyType();
     }
 
     public void setValue(Binary value) throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
@@ -305,5 +305,18 @@ public class ExternalPropertyImpl extends ExternalItemImpl implements Property {
     @Override
     public void remove() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         ((ExternalNodeImpl) getParent()).removeProperty(getName());
+    }
+
+    private int getSafePropertyType() throws RepositoryException {
+        int type = PropertyType.UNDEFINED;
+        if (value != null) {
+            type = value.getType();
+        } else if (values != null) {
+            type = values[0].getType();
+        }
+        if (type == PropertyType.UNDEFINED) {
+            throw new ValueFormatException("No value associated with this property or type is UNDEFINED");
+        }
+        return type;
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14491

## Description

https://jira.jahia.org/browse/QA-13642 was a fix done for Arkema also
https://github.com/Jahia/jahia-private/pull/775

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
