### PR TITLE
BACKLOG-20686 Add siteSettings to jahia-depends (resource load issue …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <jahia-depends>siteSettings</jahia-depends>
+        <jahia-depends>assets,jquery</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-static-resources>/css,/javascript</jahia-static-resources>

--- a/core/src/main/import/repository.xml
+++ b/core/src/main/import/repository.xml
@@ -2,7 +2,7 @@
 <content xmlns:j="http://www.jahia.org/jahia/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
     <modules jcr:primaryType="jnt:modules">
         <external-provider j:modulePriority="0"
-                           j:dependencies="siteSettings"
+                           j:dependencies="assets,jquery"
                          j:moduleType="system"
                          j:title="Jahia External Provider"
                          jcr:mixinTypes="jmix:hasExternalProviderExtension"

--- a/vfs/pom.xml
+++ b/vfs/pom.xml
@@ -34,7 +34,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <jahia-depends>external-provider,siteSettings</jahia-depends>
+        <jahia-depends>external-provider,assets,jquery</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <export-package>
             org.jahia.modules.external.vfs,

--- a/vfs/src/main/import/repository.xml
+++ b/vfs/src/main/import/repository.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <content xmlns:j="http://www.jahia.org/jahia/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
     <modules jcr:primaryType="jnt:modules">
-        <external-provider-vfs j:dependencies="external-provider,siteSettings"
+        <external-provider-vfs j:dependencies="external-provider,assets,jquery"
                              j:modulePriority="0"
                              j:moduleType="system"
                              j:title="Jahia External Provider VFS"


### PR DESCRIPTION
…in editframe)

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20686

## Description

Ok so the issue was discovered in vfs, whenever we navigate inside the frame it fails to load resources for material in jnt:template of site settings, which provides and initializes  material lib. 

It previously depended on serverSettings and I guess it worked due to the fact that serverSettings depends on siteSettings, but what we really need is siteSettings in this case. 

I added dependency for external-provider as well even though it has not been mentioned that we have an issue. But the way it is built is the same so it would be odd to have one and not the other.

Let me know if you can think of other things we can do here. 

Once merged I will update the doc for dependencies.