### PR TITLE
BACKLOG-20840: fixed test

### DIFF
--- a/test/src/main/java/org/jahia/modules/external/test/listener/ApiEventTest.java
+++ b/test/src/main/java/org/jahia/modules/external/test/listener/ApiEventTest.java
@@ -135,8 +135,9 @@ public class ApiEventTest  extends JahiaTestCase {
         ConfigurationAdmin configurationAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
         Configuration configuration = configurationAdmin.getConfiguration("org.jahia.modules.api.external_provider.event");
         originalProperties = configuration.getProperties();
-
+        List<String> keys = Collections.list(originalProperties.keys());
         Hashtable<String, Object> newProps = new Hashtable<>();
+        keys.stream().forEach(k -> newProps.put(k, originalProperties.get(k)));
         newProps.put("providers.event.api.key", "42267ebc-f8d0-4f4d-ac98-21fb8eeda653");
         configuration.update(newProps);
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20840

## Description

Config with api key is incorrectly updated, by removing the existing props - including fileinstall filename. Fileinstall cannot write the file back to the fs, cluster sync goes to browsing with incomplete file and back to processing server, removing the added api key (so, 403).
