### PR TITLE
BACKLOG-20898 Support for building OSGi EDP without using Spring

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactory.java
+++ b/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.external;
+
+/**
+ * Interface used by OSGi modules to retrieve new instances of ExternalContentStoreProvider instances
+ * that contain all the needed references already provided.
+ */
+public interface ExternalContentStoreProviderFactory {
+
+    ExternalContentStoreProvider newProvider();
+
+}

--- a/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactoryImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactoryImpl.java
@@ -20,7 +20,6 @@ import org.jahia.services.content.JCRStoreService;
 import org.jahia.services.sites.JahiaSitesService;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUserManagerService;
-import org.osgi.service.component.annotations.Reference;
 
 public class ExternalContentStoreProviderFactoryImpl implements ExternalContentStoreProviderFactory {
 
@@ -32,32 +31,26 @@ public class ExternalContentStoreProviderFactoryImpl implements ExternalContentS
 
     private ExternalProviderInitializerService externalProviderInitializerService;
 
-    @Reference
     public void setUserManagerService(JahiaUserManagerService userManagerService) {
         this.userManagerService = userManagerService;
     }
 
-    @Reference
     public void setGroupManagerService(JahiaGroupManagerService groupManagerService) {
         this.groupManagerService = groupManagerService;
     }
 
-    @Reference
     public void setSitesService(JahiaSitesService sitesService) {
         this.sitesService = sitesService;
     }
 
-    @Reference
     public void setJcrStoreService(JCRStoreService jcrStoreService) {
         this.jcrStoreService = jcrStoreService;
     }
 
-    @Reference
     public void setSessionFactory(JCRSessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
     }
 
-    @Reference
     public void setExternalProviderInitializerService(ExternalProviderInitializerService externalProviderInitializerService) {
         this.externalProviderInitializerService = externalProviderInitializerService;
     }

--- a/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactoryImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/ExternalContentStoreProviderFactoryImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.external;
+
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRStoreService;
+import org.jahia.services.sites.JahiaSitesService;
+import org.jahia.services.usermanager.JahiaGroupManagerService;
+import org.jahia.services.usermanager.JahiaUserManagerService;
+import org.osgi.service.component.annotations.Reference;
+
+public class ExternalContentStoreProviderFactoryImpl implements ExternalContentStoreProviderFactory {
+
+    private JahiaUserManagerService userManagerService;
+    private JahiaGroupManagerService groupManagerService;
+    private JahiaSitesService sitesService;
+    private JCRStoreService jcrStoreService;
+    private JCRSessionFactory sessionFactory;
+
+    private ExternalProviderInitializerService externalProviderInitializerService;
+
+    @Reference
+    public void setUserManagerService(JahiaUserManagerService userManagerService) {
+        this.userManagerService = userManagerService;
+    }
+
+    @Reference
+    public void setGroupManagerService(JahiaGroupManagerService groupManagerService) {
+        this.groupManagerService = groupManagerService;
+    }
+
+    @Reference
+    public void setSitesService(JahiaSitesService sitesService) {
+        this.sitesService = sitesService;
+    }
+
+    @Reference
+    public void setJcrStoreService(JCRStoreService jcrStoreService) {
+        this.jcrStoreService = jcrStoreService;
+    }
+
+    @Reference
+    public void setSessionFactory(JCRSessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Reference
+    public void setExternalProviderInitializerService(ExternalProviderInitializerService externalProviderInitializerService) {
+        this.externalProviderInitializerService = externalProviderInitializerService;
+    }
+
+    @Override
+    public ExternalContentStoreProvider newProvider() {
+        ExternalContentStoreProvider newProvider = new ExternalContentStoreProvider();
+        newProvider.setUserManagerService(userManagerService);
+        newProvider.setGroupManagerService(groupManagerService);
+        newProvider.setSitesService(sitesService);
+        newProvider.setService(jcrStoreService);
+        newProvider.setSessionFactory(sessionFactory);
+        newProvider.setExternalProviderInitializerService(externalProviderInitializerService);
+        return newProvider;
+    }
+
+}

--- a/core/src/main/resources/META-INF/spring/mod-external-provider.xml
+++ b/core/src/main/resources/META-INF/spring/mod-external-provider.xml
@@ -60,4 +60,15 @@
             <entry key="service.pid" value="org.jahia.modules.external.mount"/>
         </osgi:service-properties>
     </osgi:service>
+
+    <bean id="externalContentStoreProviderFactory" class="org.jahia.modules.external.ExternalContentStoreProviderFactoryImpl">
+        <property name="userManagerService" ref="JahiaUserManagerService"/>
+        <property name="groupManagerService" ref="JahiaGroupManagerService"/>
+        <property name="sitesService" ref="JahiaSitesService"/>
+        <property name="jcrStoreService" ref="JCRStoreService"/>
+        <property name="sessionFactory" ref="jcrSessionFactory"/>
+        <property name="externalProviderInitializerService" ref="ProviderInitializerService" />
+    </bean>
+    <osgi:service id="externalContentStoreProviderFactoryOsgi" ref="externalContentStoreProviderFactory" interface="org.jahia.modules.external.ExternalContentStoreProviderFactory"/>
+
 </beans>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20898

## Description

This PoC was simplified to the absolute minimum. It originally started with more complex implementations that might have been working, but in the end, this solution was the best combination of:
- simplicity
- compatibility with older EDP providers
- fulfilling requirements for 100% OSGi EDP implementation. A test implementation has been done using the tmdb-provider (https://github.com/Jahia/tmdb-provider) project.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
