### PR TITLE
BACKLOG-21905: Fix graphql mount status return value; Mount node on modify

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,180 @@ External Provider
 ======================
 The External Provider module provides an API allowing integration of external system as content providers.
 
+## GraphQL API
+
+GraphQL API endpoints are available for creating and modifying basic and VFS mount points, as well as mount and unmount and query operations. Other mount point provider modules can also extend endpoints with the same namespaces `mutation.admin.mountpoint` and `query.admin.mountpoint`. 
+
+#### Mutations (`mutation.admin.mountpoint`)
+
+- add
+
+```
+add
+Create a simple mount point node in /mounts
+
+Type
+String
+Returns the uuid of the created mount point node
+
+Arguments
+name: String!
+Mount point name
+
+mountPointRefPath: String
+Target local mount point
+```
+
+- addVfs
+
+```
+addVfs
+Create a VFS mount point node in /mounts
+
+Type
+String
+Returns the uuid of the mount point node
+
+Arguments
+name: String!
+Name for the mount point
+
+mountPointRefPath: String
+Target local mount point
+
+rootPath: String
+VFS root mount point
+```
+
+- modify 
+
+```
+Modify an existing mount point node
+
+Type
+Boolean
+Return true if operation is successful
+
+Arguments
+pathOrId: String!
+Mount point path or ID to modify
+
+name: String
+Rename existing mount point
+
+mountPointRefPath: String
+Change local mount point, or set to empty string to remove
+```
+
+- modifyVfs
+```
+modifyVfs
+Modify an existing mount point node
+
+Type
+Boolean
+Return true if operation is successful
+
+Arguments
+pathOrId: String!
+Mount point path or ID to modify
+
+name: String
+Rename existing mount point
+
+mountPointRefPath: String
+Change target local mount point, or set to empty string to remove
+
+rootPath: String
+VFS root mount point
+```
+
+- mount
+
+```
+mount
+Mount an existing mount point
+
+Type
+Boolean
+Return true if operation is successful
+
+Arguments
+pathOrId: String!
+Mount point path or ID to mount
+```
+
+- unmount
+```
+unmount
+Unount an existing mount point
+
+Type
+Boolean
+Return true if operation is successful
+
+Arguments
+pathOrId: String!
+Mount point path or ID to mount
+```
+
+#### Queries (`query.admin.mountpoint`)
+
+- mountPoint 
+
+```
+mountPoint
+Get mount point with given name, or null if it doesn't exists
+
+Type
+GqlMountPoint
+Return GqlMountPoint object
+
+Arguments
+name: String!
+Name for the mount point
+```
+
+- mountPoints
+
+```
+mountPoints
+Get list of mount points, or empty list if no mounts exist
+
+Type
+[GqlMountPoint]
+Return list of GqlMountPoint objects
+```
+
+- Type GqlMountPoint
+
+```
+GqlMountPoint
+Mount point object
+
+Fields
+mountName: String
+Mount point name
+
+mountPointRefPath: String
+Mount point local reference path
+
+mountStatus: String
+Mount status
+
+nodeType: String
+Mount node type
+
+properties: [GqlMountPointProperty]
+Mount point additional properties
+
+property(name: String!): String
+Mount point property
+
+uuid: String
+Mount point node uuid
+```
+
 ## Open-Source
 
 This is an Open-Source module, you can find more details about Open-Source @ Jahia [in this repository](https://github.com/Jahia/open-source).

--- a/core/src/main/java/org/jahia/modules/external/service/MountPoint.java
+++ b/core/src/main/java/org/jahia/modules/external/service/MountPoint.java
@@ -57,7 +57,7 @@ public class MountPoint {
 
     private MountStatus mountStatus;
 
-    private String primaryNodeType = Constants.JAHIANT_MOUNTPOINT;;
+    private String primaryNodeType = Constants.JAHIANT_MOUNTPOINT;
 
     private Map<String, String> mountProperties;
 

--- a/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
@@ -135,8 +135,11 @@ public class MountPointServiceImpl implements MountPointService {
 
     public boolean isMounted(JCRMountPointNode mountPointNode) {
         try {
+            // make an exception for jnt:mountPoint as it does not return a mount provider
+            boolean baseMounted = mountPointNode.getPrimaryNodeType().isNodeType(Constants.JAHIANT_MOUNTPOINT)
+                    && mountPointNode.getMountStatus() == MountStatus.mounted;
             JCRStoreProvider mountProvider = mountPointNode.getMountProvider();
-            return mountProvider != null && mountProvider.isAvailable();
+            return baseMounted || (mountProvider != null && mountProvider.isAvailable());
         } catch (RepositoryException ignored) {}
 
         return false;

--- a/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
@@ -83,6 +83,7 @@ public class MountPointServiceImpl implements MountPointService {
                 jcrMountPointNode.rename(jcrMountName);
             }
 
+            jcrMountPointNode.setMountStatus(JCRMountPointNode.MountStatus.mounted);
             setMountPointRefPath(mountPoint, session, jcrMountPointNode);
 
             // set additional mount point node properties

--- a/tests/cypress/e2e/api.cy.ts
+++ b/tests/cypress/e2e/api.cy.ts
@@ -76,12 +76,12 @@ describe('GraphQL endpoint tests', () => {
             });
         });
 
-        it('get all mount points', () => {
+        it('get all mount points including simple', () => {
             cy.apollo({
                 queryFile: 'mountInfos.graphql'
             }).then(resp => {
                 expect(resp.data.admin.mountPoint.mountPoints).to.not.be.empty;
-                expect(resp.data.admin.mountPoint.mountPoints.length).to.equal(2, 'Duplicate mount point nodes');
+                expect(resp.data.admin.mountPoint.mountPoints.length).to.equal(3);
             });
         });
 

--- a/tests/cypress/e2e/api.cy.ts
+++ b/tests/cypress/e2e/api.cy.ts
@@ -1,4 +1,5 @@
 describe('GraphQL endpoint tests', () => {
+
     before(function () {
         cy.executeGroovy('cleanup.groovy');
         cy.executeGroovy('createDir.groovy');
@@ -8,115 +9,165 @@ describe('GraphQL endpoint tests', () => {
         cy.executeGroovy('cleanup.groovy');
     });
 
-    const mountInfo = {name: 'my-vfs-mount', rootPath: '/tmp/mount-test'};
-
-    it('create VFS mount point', () => {
-        cy.apollo({
-            mutationFile: 'mountVfs.graphql',
-            variables: {...mountInfo, mountPointRefPath: '/sites/digitall/files'}
-        }).then(resp => {
-            expect(resp.data.admin.mountPoint.addVfs).to.not.be.empty;
-        });
-    });
-
-    it('create duplicate VFS mount point name with local', () => {
-        cy.apollo({
-            mutationFile: 'mountVfs.graphql',
-            variables: mountInfo
-        }).then(resp => {
-            expect(resp.data.admin.mountPoint.addVfs).to.not.be.empty;
-        });
-    });
-
-    it('get all mount points', () => {
-        cy.apollo({
-            queryFile: 'mountInfos.graphql'
-        }).then(resp => {
-            expect(resp.data.admin.mountPoint.mountPoints).to.not.be.empty;
-            expect(resp.data.admin.mountPoint.mountPoints.length).to.equal(2, 'Duplicate mount point nodes');
-        });
-    });
-
-    it('get mount point information', () => {
-        cy.apollo({
-            queryFile: 'mountInfo.graphql',
-            variables: {name: 'my-vfs-mount'}
-        }).then(resp => {
-            const mountPoint = resp.data.admin.mountPoint.mountPoint;
-            expect(mountPoint).to.not.be.empty;
-            expect(mountPoint.mountName).to.equal('my-vfs-mount');
-            expect(mountPoint.mountStatus).to.equal('mounted');
-            expect(mountPoint.mountPointRefPath).to.equal('/sites/digitall/files/my-vfs-mount');
-            expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
-        });
-    });
-
-    it('modify mount point', () => {
-        cy.apollo({
-            queryFile: 'mountInfo.graphql',
-            variables: {name: 'my-vfs-mount-1'}
-        }).its('data.admin.mountPoint.mountPoint.uuid').as('nodeId');
-
-        cy.get('@nodeId').then(nodeId => {
+    describe('Simple mount point', () => {
+        it('create simple mount point', () => {
             cy.apollo({
-                mutationFile: 'modifyVfs.graphql',
-                variables: {
-                    pathOrId: nodeId,
-                    name: 'new-mount-name'
-                }
+                mutationFile: 'mountSimple.graphql',
+                variables: {name: 'simple'}
             }).then(resp => {
-                expect(resp.data.admin.mountPoint.modifyVfs).to.be.true;
+                expect(resp.data.admin.mountPoint.add).to.not.be.empty;
+            });
+        });
+
+        it('unmount mount point', () => {
+            cy.apollo({
+                queryFile: 'unmount.graphql',
+                variables: {pathOrId: '/mounts/simple-mount'}
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.unmount).to.be.true;
+            });
+
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'simple'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountStatus).to.equal('unmounted');
+            });
+        });
+
+        it('remount mount point', () => {
+            cy.apollo({
+                queryFile: 'mounted.graphql',
+                variables: {pathOrId: '/mounts/simple-mount'}
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.mount).to.be.true;
+            });
+
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'simple'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountStatus).to.equal('mounted');
             });
         });
     });
 
-    it('get modified mount point information', () => {
-        cy.apollo({
-            queryFile: 'mountInfo.graphql',
-            variables: {name: 'new-mount-name'}
-        }).then(resp => {
-            const mountPoint = resp.data.admin.mountPoint.mountPoint;
-            expect(mountPoint).to.not.be.empty;
-            expect(mountPoint.mountName).to.equal('new-mount-name');
-            expect(mountPoint.mountStatus).to.equal('mounted');
-            expect(mountPoint.mountPointRefPath).to.equal('/mounts/new-mount-name');
-            expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
+    describe('VFS mount point', () => {
+        const mountInfo = {name: 'my-vfs-mount', rootPath: '/tmp/mount-test'};
+
+        it('create VFS mount point', () => {
+            cy.apollo({
+                mutationFile: 'mountVfs.graphql',
+                variables: {...mountInfo, mountPointRefPath: '/sites/digitall/files'}
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.addVfs).to.not.be.empty;
+            });
+        });
+
+        it('create duplicate VFS mount point name with local', () => {
+            cy.apollo({
+                mutationFile: 'mountVfs.graphql',
+                variables: mountInfo
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.addVfs).to.not.be.empty;
+            });
+        });
+
+        it('get all mount points', () => {
+            cy.apollo({
+                queryFile: 'mountInfos.graphql'
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.mountPoints).to.not.be.empty;
+                expect(resp.data.admin.mountPoint.mountPoints.length).to.equal(2, 'Duplicate mount point nodes');
+            });
+        });
+
+        it('get mount point information', () => {
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'my-vfs-mount'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountName).to.equal('my-vfs-mount');
+                expect(mountPoint.mountStatus).to.equal('mounted');
+                expect(mountPoint.mountPointRefPath).to.equal('/sites/digitall/files/my-vfs-mount');
+                expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
+            });
+        });
+
+        it('modify mount point', () => {
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'my-vfs-mount-1'}
+            }).its('data.admin.mountPoint.mountPoint.uuid').as('nodeId');
+
+            cy.get('@nodeId').then(nodeId => {
+                cy.apollo({
+                    mutationFile: 'modifyVfs.graphql',
+                    variables: {
+                        pathOrId: nodeId,
+                        name: 'new-mount-name'
+                    }
+                }).then(resp => {
+                    expect(resp.data.admin.mountPoint.modifyVfs).to.be.true;
+                });
+            });
+        });
+
+        it('get modified mount point information', () => {
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'new-mount-name'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountName).to.equal('new-mount-name');
+                expect(mountPoint.mountStatus).to.equal('mounted');
+                expect(mountPoint.mountPointRefPath).to.equal('/mounts/new-mount-name');
+                expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
+            });
+        });
+
+        it('unmount mount point', () => {
+            cy.apollo({
+                queryFile: 'unmount.graphql',
+                variables: {pathOrId: '/mounts/new-mount-name-mount'}
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.unmount).to.be.true;
+            });
+
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'new-mount-name'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountStatus).to.equal('unmounted');
+            });
+        });
+
+        it('remount mount point', () => {
+            cy.apollo({
+                queryFile: 'mounted.graphql',
+                variables: {pathOrId: '/mounts/new-mount-name-mount'}
+            }).then(resp => {
+                expect(resp.data.admin.mountPoint.mount).to.be.true;
+            });
+
+            cy.apollo({
+                queryFile: 'mountInfo.graphql',
+                variables: {name: 'new-mount-name'}
+            }).then(resp => {
+                const mountPoint = resp.data.admin.mountPoint.mountPoint;
+                expect(mountPoint).to.not.be.empty;
+                expect(mountPoint.mountStatus).to.equal('mounted');
+            });
         });
     });
 
-    it('unmount mount point', () => {
-        cy.apollo({
-            queryFile: 'unmount.graphql',
-            variables: {pathOrId: '/mounts/new-mount-name-mount'}
-        }).then(resp => {
-            expect(resp.data.admin.mountPoint.unmount).to.be.true;
-        });
-
-        cy.apollo({
-            queryFile: 'mountInfo.graphql',
-            variables: {name: 'new-mount-name'}
-        }).then(resp => {
-            const mountPoint = resp.data.admin.mountPoint.mountPoint;
-            expect(mountPoint).to.not.be.empty;
-            expect(mountPoint.mountStatus).to.equal('unmounted');
-        });
-    });
-
-    it('remount mount point', () => {
-        cy.apollo({
-            queryFile: 'mounted.graphql',
-            variables: {pathOrId: '/mounts/new-mount-name-mount'}
-        }).then(resp => {
-            expect(resp.data.admin.mountPoint.mount).to.be.true;
-        });
-
-        cy.apollo({
-            queryFile: 'mountInfo.graphql',
-            variables: {name: 'new-mount-name'}
-        }).then(resp => {
-            const mountPoint = resp.data.admin.mountPoint.mountPoint;
-            expect(mountPoint).to.not.be.empty;
-            expect(mountPoint.mountStatus).to.equal('mounted');
-        });
-    });
 });

--- a/tests/cypress/e2e/api.cy.ts
+++ b/tests/cypress/e2e/api.cy.ts
@@ -95,7 +95,9 @@ describe('GraphQL endpoint tests', () => {
                 expect(mountPoint.mountName).to.equal('my-vfs-mount');
                 expect(mountPoint.mountStatus).to.equal('mounted');
                 expect(mountPoint.mountPointRefPath).to.equal('/sites/digitall/files/my-vfs-mount');
-                expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
+                // eslint-disable-next-line max-nested-callbacks
+                const rootPath = mountPoint.properties.find(p => p.key === 'j:rootPath').value;
+                expect(rootPath).to.equal('/tmp/mount-test');
             });
         });
 
@@ -112,7 +114,7 @@ describe('GraphQL endpoint tests', () => {
                         pathOrId: nodeId,
                         name: 'new-mount-name'
                     }
-                }).then(resp => {
+                }).then(resp => { // eslint-disable-line max-nested-callbacks
                     expect(resp.data.admin.mountPoint.modifyVfs).to.be.true;
                 });
             });
@@ -128,6 +130,7 @@ describe('GraphQL endpoint tests', () => {
                 expect(mountPoint.mountName).to.equal('new-mount-name');
                 expect(mountPoint.mountStatus).to.equal('mounted');
                 expect(mountPoint.mountPointRefPath).to.equal('/mounts/new-mount-name');
+                // eslint-disable-next-line max-nested-callbacks
                 expect(mountPoint.properties.find(p => p.key === 'j:rootPath').value).to.equal('/tmp/mount-test');
             });
         });

--- a/tests/cypress/e2e/api.cy.ts
+++ b/tests/cypress/e2e/api.cy.ts
@@ -1,5 +1,4 @@
 describe('GraphQL endpoint tests', () => {
-
     before(function () {
         cy.executeGroovy('cleanup.groovy');
         cy.executeGroovy('createDir.groovy');
@@ -169,5 +168,4 @@ describe('GraphQL endpoint tests', () => {
             });
         });
     });
-
 });

--- a/tests/cypress/e2e/vfs.cy.ts
+++ b/tests/cypress/e2e/vfs.cy.ts
@@ -124,6 +124,7 @@ describe('VFS mount operations tests', () => {
                 variables: {path: '/mounts/mount-test'},
                 errorPolicy: 'all'
             }).should(({errors}) => {
+                // eslint-disable-next-line max-nested-callbacks
                 expect('javax.jcr.AccessDeniedException: /').to.be.oneOf(errors.map(e => e.message));
             });
             cy.executeGroovy('checkFile.groovy', {'#path#': '/tmp/mount-test/toto'}).should(r => {

--- a/tests/cypress/fixtures/mountSimple.graphql
+++ b/tests/cypress/fixtures/mountSimple.graphql
@@ -1,0 +1,7 @@
+mutation mountSimple($name: String!, $mountPointRefPath: String) {
+    admin {
+        mountPoint {
+            add(name: $name, mountPointRefPath: $mountPointRefPath)
+        }
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21905

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Fix issues with gql mount status return value
* Add cypress tests for simple mount point
* Add gql documentation in README
* Add lint exceptions due to nested callbacks on cypress test structure