### PR TITLE
BACKLOG-22002: Fix specific postgresql queries for fetching/updating oid columns

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/id/ExternalProviderInitializerServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/id/ExternalProviderInitializerServiceImpl.java
@@ -107,10 +107,12 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
         }
         if (includeDescendants) {
             boolean isPostgreSQL = DatabaseUtils.getDatabaseType() == DatabaseUtils.DatabaseType.postgresql;
-
-            String selectDescendantMapping = isPostgreSQL ? "SELECT internalUuid, convert_from(lo_get(cast(externalid as bigint)), 'UTF8') as externalid FROM jahia_external_mapping WHERE providerKey=? and convert_from(lo_get(cast(externalid as bigint)), 'UTF8') like ?"
-                    : "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? and externalId like ?";
-            try (Connection connection = datasource.getConnection(); PreparedStatement statement = connection.prepareStatement(selectDescendantMapping)) {
+            String selectDescendantMapping = isPostgreSQL ?
+                    "SELECT internalUuid, convert_from(lo_get(cast(externalId as bigint)), 'UTF8') as externalId FROM "
+                            + "jahia_external_mapping WHERE providerKey=? and convert_from(lo_get(cast(externalid as bigint)), 'UTF8') like ?" : 
+                    "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? and externalId like ?";
+            try (Connection connection = datasource.getConnection();
+                    PreparedStatement statement = connection.prepareStatement(selectDescendantMapping)) {
                 connection.setAutoCommit(false);
                 for (String externalId : externalIds) {
                     statement.setString(1, providerKey);
@@ -173,7 +175,6 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
 
     private String getExternalId(ResultSet resultSet, int columnIndex) throws IOException, SQLException {
         boolean isPostgreSQL = DatabaseUtils.getDatabaseType() == DatabaseUtils.DatabaseType.postgresql;
-
         if (isPostgreSQL) {
             return IOUtils.toString(resultSet.getCharacterStream(columnIndex));
         } else {
@@ -259,8 +260,11 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
         uuidMapping.setInternalUuid(providerId + "-" + StringUtils.substringAfter(UUID.randomUUID().toString(), "-"));
 
         boolean isPostgreSQL = DatabaseUtils.getDatabaseType() == DatabaseUtils.DatabaseType.postgresql;
-        String insertNewMapping = isPostgreSQL ? "INSERT INTO jahia_external_mapping(providerKey, externalId, externalIdHash, internalUuid) values (?,lo_from_bytea(0, ?),?,?)" : "INSERT INTO jahia_external_mapping(providerKey, externalId, externalIdHash, internalUuid) values (?,?,?,?)";
-        try (Connection connection = datasource.getConnection(); PreparedStatement statement = connection.prepareStatement(insertNewMapping)) {
+        String insertNewMapping = isPostgreSQL ?
+                "INSERT INTO jahia_external_mapping(providerKey, externalId, externalIdHash, internalUuid) values (?,lo_from_bytea(0, ?),?,?)" :
+                "INSERT INTO jahia_external_mapping(providerKey, externalId, externalIdHash, internalUuid) values (?,?,?,?)";
+        try (Connection connection = datasource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(insertNewMapping)) {
             statement.setString(1, uuidMapping.getProviderKey());
             if (isPostgreSQL) {
                 statement.setBytes(2, externalId.getBytes(StandardCharsets.UTF_8));
@@ -322,8 +326,11 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
         boolean isPostgreSQL = DatabaseUtils.getDatabaseType() == DatabaseUtils.DatabaseType.postgresql;
         List<String> invalidate = new ArrayList<>();
         String selectMapping = "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? AND externalIdHash=?";
-        String updateMapping = isPostgreSQL ? "UPDATE jahia_external_mapping SET externalId=lo_from_bytea(0, ?), externalIdHash=? WHERE internalUuid=?" : "UPDATE jahia_external_mapping SET externalId=?, externalIdHash=? WHERE internalUuid=?";
-        try (Connection connection = datasource.getConnection(); PreparedStatement statement = connection.prepareStatement(selectMapping)) {
+        String updateMapping = isPostgreSQL ?
+                "UPDATE jahia_external_mapping SET externalId=lo_from_bytea(0, ?), externalIdHash=? WHERE internalUuid=?" :
+                "UPDATE jahia_external_mapping SET externalId=?, externalIdHash=? WHERE internalUuid=?";
+        try (Connection connection = datasource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(selectMapping)) {
             connection.setAutoCommit(false);
             statement.setString(1, providerKey);
             statement.setInt(2, oldExternalId.hashCode());
@@ -358,9 +365,12 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
                     "Issue when updating mapping for external provider " + providerKey, e);
         }
         if (includeDescendants) {
-            String selectDescendantMapping = isPostgreSQL ? "SELECT internalUuid, convert_from(lo_get(cast(externalid as bigint)), 'UTF8') as externalid FROM jahia_external_mapping WHERE providerKey=? and convert_from(lo_get(cast(externalid as bigint)), 'UTF8') like ?"
-                    : "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? and externalId like ?";
-            try (Connection connection = datasource.getConnection(); PreparedStatement statement = connection.prepareStatement(selectDescendantMapping)) {
+            String selectDescendantMapping = isPostgreSQL ?
+                    "SELECT internalUuid, convert_from(lo_get(cast(externalid as bigint)), 'UTF8') as externalid FROM jahia_external_mapping"
+                            + " WHERE providerKey=? and convert_from(lo_get(cast(externalid as bigint)), 'UTF8') like ?" :
+                    "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? and externalId like ?";
+            try (Connection connection = datasource.getConnection();
+                    PreparedStatement statement = connection.prepareStatement(selectDescendantMapping)) {
                 connection.setAutoCommit(false);
                 statement.setString(1, providerKey);
                 statement.setString(2, oldExternalId + "/%");
@@ -371,7 +381,6 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
                         String internalId = resultSet.getString(1);
                         try (PreparedStatement updateExternalId = connection.prepareStatement(updateMapping)) {
                             String updatedExternalId = newExternalId + StringUtils.substringAfter(externalId, oldExternalId);
-
                             if (isPostgreSQL) {
                                 updateExternalId.setBytes(1, updatedExternalId.getBytes(StandardCharsets.UTF_8));
                             } else {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22002
https://jira.jahia.org/browse/BACKLOG-22387

## Description

Handle postgres queries separately

Issue is from fetching/updating oid columns which requires a bit more transformation than standard blob. We are using built-in pgsql functions > v10.

