### PR TITLE
BACKLOG-22906: Unable to upgrade external provider 4.8.0-SN

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,14 +49,14 @@
             org.jahia.modules.external.query,
             org.jahia.modules.external.service
         </export-package>
-        <jahia.modules.importPackage>
+        <import-package>
             com.google.common.base,
             com.google.common.collect,
             org.jahia.defaults.config.spring,
             org.jahia.exceptions,
             org.jahia.services,
             javassist.util.proxy
-        </jahia.modules.importPackage>
+        </import-package>
         <jackson.version>2.9.0</jackson.version>
         <jersey.version>2.6</jersey.version>
         <jahia-module-signature>MCwCFDFdmFUQXE+wCOIheRuJoaC7qXixAhQ5qUczQ11igPyTeuGlKKR8vVvRcQ==</jahia-module-signature>

--- a/external-provider-ui/pom.xml
+++ b/external-provider-ui/pom.xml
@@ -46,13 +46,14 @@
             org.jahia.modules.external.admin.mount,
             org.jahia.modules.external.admin.mount.validator
         </export-package>
-        <jahia.modules.importPackage>
-            org.jahia.modules.external,
+        <import-package>
+            org.jahia.modules.external;version="[4.2,5)",
+            org.jahia.modules.external.service;version="[4.2,5)",
             org.jahia.defaults.config.spring,
             org.jahia.exceptions,
             org.jahia.services,
             javassist.util.proxy
-        </jahia.modules.importPackage>
+        </import-package>
         <jahia-module-signature>MC0CFDMGZgQ7mD1ASVC2zvvy1KOao6BFAhUAjNuAlk7TAwUcEiut2t/xUzMLitQ=</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <yarn.arguments>build:production</yarn.arguments>

--- a/vfs/pom.xml
+++ b/vfs/pom.xml
@@ -46,6 +46,7 @@
         <jahia-module-signature>MCwCFCX/bCE0QH2LL3APB/vBRK82u2LSAhQBwbnb0yR9CEG7YnHPqsyrHvqJ7w==</jahia-module-signature>
         <import-package>
             org.jahia.modules.external;version="[4.2,5)",
+            org.jahia.modules.external.service;version="[4.2,5)",
             org.jahia.defaults.config.spring,
             org.apache.naming.java,
             org.springframework.web.servlet.tags.form


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-22906

## Description

Unable to provision upgrade for external provider (core + vfs + modules + ui) due to lake of OSGI import package but also hide by a NPE on exception cause in DQGraphQLProvider

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability
