### PR TITLE
BACKLOG-22971: Add annotation on ExternalStoreProviderPrototype bean declaration

### DIFF
--- a/core/src/main/resources/META-INF/spring/mod-external-provider.xml
+++ b/core/src/main/resources/META-INF/spring/mod-external-provider.xml
@@ -31,6 +31,7 @@
 
     <osgi:service id="ExternalProviderInitializerService" ref="ProviderInitializerService" interface="org.jahia.modules.external.ExternalProviderInitializerService"/>
 
+    <!-- Also exposed through ExternalContentStoreProviderFactory OSGI service -->
     <bean id="ExternalStoreProviderPrototype" class="org.jahia.modules.external.ExternalContentStoreProvider"
           parent="AbstractJCRStoreProviderPrototype" scope="prototype">
         <property name="externalProviderInitializerService" ref="ProviderInitializerService"/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22971

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add comment about available alternative initialization using OSGi service