### PR TITLE
BACKLOG-23145 : remove jcontent from provisioning as not required anymore for testing

### DIFF
--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -32,7 +32,6 @@
 - importSite: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/Digitall.zip"
 
 - installBundle:
-  - 'mvn:org.jahia.modules/jcontent'
   - 'mvn:org.jahia.test/jahia-test-module'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -32,7 +32,6 @@
 - importSite: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/Digitall.zip"
 
 - installBundle:
-  - 'mvn:org.jahia.modules/jcontent'
   - 'mvn:org.jahia.test/jahia-test-module'
   - 'mvn:org.jahia.modules/external-provider'
   - 'mvn:org.jahia.modules/external-provider-ui'


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23145