### PR TITLE
SEC-133: GraphQL VFS mount point API security permissions

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/graphql/AdminMutationExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/AdminMutationExtension.java
@@ -28,7 +28,9 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminMutation;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
+@Deprecated(since = "4.8.0", forRemoval = true)
 @GraphQLTypeExtension(GqlAdminMutation.class)
 @GraphQLDescription("Mutation extensions for mount point")
 public class AdminMutationExtension {
@@ -36,6 +38,7 @@ public class AdminMutationExtension {
     @GraphQLField
     @GraphQLName("mountPoint")
     @GraphQLDescription("Mount point mutation extension API")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public static GqlMountPointMutation mountPoint() {
         return new GqlMountPointMutation();
     }

--- a/core/src/main/java/org/jahia/modules/external/graphql/AdminQueryExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/AdminQueryExtension.java
@@ -38,7 +38,7 @@ public class AdminQueryExtension {
     @GraphQLField
     @GraphQLName("mountPoint")
     @GraphQLDescription("Mount point query extension API")
-    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
+    @GraphQLRequiresPermission(value = "graphqlAdminQuery")
     public static GqlMountPointQuery mountPoint() {
         return new GqlMountPointQuery();
     }

--- a/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointExtensionsProvider.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointExtensionsProvider.java
@@ -37,6 +37,6 @@ public class GqlMountPointExtensionsProvider implements DXGraphQLExtensionsProvi
 
     @Override
     public Collection<Class<?>> getExtensions() {
-        return Arrays.<Class<?>>asList(AdminMutationExtension.class, AdminQueryExtension.class);
+        return Arrays.<Class<?>>asList(AdminMutationExtension.class, AdminQueryExtension.class, JahiaAdminMutationExtension.class, JahiaAdminQueryExtension.class);
     }
 }

--- a/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminMutationExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminMutationExtension.java
@@ -27,19 +27,16 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
-import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminQuery;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminMutation;
 
-@Deprecated(since = "4.8.0", forRemoval = true)
-@GraphQLTypeExtension(GqlAdminQuery.class)
-@GraphQLDescription("Query extensions for mount point")
-public class AdminQueryExtension {
+@GraphQLTypeExtension(GqlJahiaAdminMutation.class)
+@GraphQLDescription("Mutation extensions for mount point")
+public class JahiaAdminMutationExtension {
 
     @GraphQLField
     @GraphQLName("mountPoint")
-    @GraphQLDescription("Mount point query extension API")
-    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
-    public static GqlMountPointQuery mountPoint() {
-        return new GqlMountPointQuery();
+    @GraphQLDescription("Mount point mutation extension API")
+    public static GqlMountPointMutation mountPoint() {
+        return new GqlMountPointMutation();
     }
 }

--- a/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminQueryExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminQueryExtension.java
@@ -28,17 +28,16 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminQuery;
+import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminQuery;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
-@Deprecated(since = "4.8.0", forRemoval = true)
-@GraphQLTypeExtension(GqlAdminQuery.class)
+@GraphQLTypeExtension(GqlJahiaAdminQuery.class)
 @GraphQLDescription("Query extensions for mount point")
-public class AdminQueryExtension {
+public class JahiaAdminQueryExtension {
 
     @GraphQLField
     @GraphQLName("mountPoint")
     @GraphQLDescription("Mount point query extension API")
-    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public static GqlMountPointQuery mountPoint() {
         return new GqlMountPointQuery();
     }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/SEC-133

## Description

Add specific security constraints to GraphQL Extensions (admin and query) to enforce admin permissions.
Extensions are moved to /admin/jahia QraphQL endpoints for inherited permissions ; old endpoints are preserved and marked as merged but with an explicit permission constraint.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
