### PR TITLE
ci: added the ability to trigger the on-merge workflow manually

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -4,6 +4,7 @@ name: On merge to master
 
 # The workflow could also be triggered on PRs
 on:
+  workflow_dispatch:  
   push:
     branches:
       - 'master'


### PR DESCRIPTION
This is generally useful to generate SNAPSHOT artifacts just after a release.

In our situation, that would help us understand/debug why 4.9.0-SN is installed via provisioning while 4.9.0 was released.