### PR TITLE
test: fix vfs failing test by not relying on external resources.

### DIFF
--- a/tests/cypress/fixtures/createDir.groovy
+++ b/tests/cypress/fixtures/createDir.groovy
@@ -1,3 +1,6 @@
 new File("/tmp/mount-test").mkdir()
-org.apache.commons.io.FileUtils.copyDirectory(new File('/usr/local/tomcat/webapps.dist/docs'), new File('/tmp/mount-test'));
+new File("/tmp/mount-test/images").mkdir()
 
+// Create dummy files used for testing
+new File("/tmp/mount-test/images/tomcat.gif").createNewFile()
+new File("/tmp/mount-test/index.html").createNewFile()


### PR DESCRIPTION
Remove usage of external resources in Cypress tests