### PR TITLE
refactor: small improvements regarding hashes query

### DIFF
--- a/core/src/main/java/org/jahia/modules/external/id/ExternalProviderInitializerServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/id/ExternalProviderInitializerServiceImpl.java
@@ -469,13 +469,9 @@ public class ExternalProviderInitializerServiceImpl implements ExternalProviderI
     }
 
     private void collectMappings(Set<String> externalIdsSet, Connection connection, String providerKey, BiConsumer<String, String> processMapping) throws SQLException, IOException {
-        List<Integer> hashes = new LinkedList<>();
-        for (String externalId : externalIdsSet) {
-            int hash = externalId.hashCode();
-            if (!hashes.contains(hash)) {
-                hashes.add(hash);
-            }
-        }
+        Set<Integer> hashes = externalIdsSet.stream()
+                .map(String::hashCode)
+                .collect(Collectors.toSet());
 
         String selectMappingTemplate = "SELECT internalUuid, externalId FROM jahia_external_mapping WHERE providerKey=? AND externalIdHash in (:listPlaceHolder)";
         String selectMapping = selectMappingTemplate.replace(":listPlaceHolder", hashes.stream().map(integer -> "?").collect(Collectors.joining(",")));


### PR DESCRIPTION
This pull request refactors the way unique hash codes are collected from a set of external IDs in the `ExternalProviderInitializerServiceImpl.java` file. The update improves efficiency and code readability by replacing a manual list-based approach with a more concise and performant set-based stream operation.

**Efficiency and code quality improvements:**

* Replaced the manual loop that built a `List<Integer>` of unique hash codes with a stream-based approach that collects hash codes into a `Set<Integer>`, ensuring uniqueness and improving performance. (`core/src/main/java/org/jahia/modules/external/id/ExternalProviderInitializerServiceImpl.java`)