### PR TITLE
fix: do not force dependencies refresh of external-provider-ui at Jahia startup

### DIFF
--- a/.chachalog/Buk1VAUa.md
+++ b/.chachalog/Buk1VAUa.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+external-provider: patch
+---
+
+**external-provider-ui**: Prevented startup deadlock by skipping manual bundle refreshes during the initial OSGi start-level transition. (#226)

--- a/external-provider-ui/src/main/java/org/jahia/modules/external/admin/Activator.java
+++ b/external-provider-ui/src/main/java/org/jahia/modules/external/admin/Activator.java
@@ -20,16 +20,27 @@ public class Activator {
 
     @Activate
     public void start(BundleContext context) {
-        Set<Bundle> wiredBundles = context.getBundle().adapt(BundleWiring.class).getProvidedWires("osgi.wiring.package").stream().map(x -> x.getRequirer().getBundle()).collect(Collectors.toSet());
-        Set<Bundle> toRefresh = Arrays.stream(context.getBundles())
-                .filter(b -> b.getHeaders().get("Import-Package") != null && b.getHeaders().get("Import-Package").contains("org.jahia.modules.external.admin"))
-                .filter(b -> !wiredBundles.contains(b))
-                .filter(b -> b.getState() == Bundle.RESOLVED || b.getState() == Bundle.ACTIVE)
-                .collect(Collectors.toSet());
-        logger.info("Refreshing {} bundles in external-provider-ui:", toRefresh.size());
-        toRefresh.forEach(b -> logger.info("Refreshing bundle - {}:{}", b.getSymbolicName(), b.getBundleId()));
-        if (!toRefresh.isEmpty()) {
-            BundleLifecycleUtils.refreshBundles(toRefresh);
+
+        int currentLevel = BundleLifecycleUtils.getFrameworkStartLevel() ;
+        // 100 is the "fully booted" state, as defined in  org.jahia.osgi.FrameWorkservice.finalFrameworkStartLevel
+        boolean isSystemStarting = BundleLifecycleUtils.getFrameworkStartLevel() < 100;
+
+        if (isSystemStarting) {
+            logger.info("System is still booting (Level {}). Skipping synchronous refresh", currentLevel);
+            // Option: Schedule a background task or register a listener instead
+        } else {
+            logger.info("Bundle started manually/individually. Proceeding with refresh logic.");
+            Set<Bundle> wiredBundles = context.getBundle().adapt(BundleWiring.class).getProvidedWires("osgi.wiring.package").stream().map(x -> x.getRequirer().getBundle()).collect(Collectors.toSet());
+            Set<Bundle> toRefresh = Arrays.stream(context.getBundles())
+                    .filter(b -> b.getHeaders().get("Import-Package") != null && b.getHeaders().get("Import-Package").contains("org.jahia.modules.external.admin"))
+                    .filter(b -> !wiredBundles.contains(b))
+                    .filter(b -> b.getState() == Bundle.RESOLVED || b.getState() == Bundle.ACTIVE)
+                    .collect(Collectors.toSet());
+            logger.info("Refreshing {} bundles in external-provider-ui:", toRefresh.size());
+            toRefresh.forEach(b -> logger.info("Refreshing bundle - {}:{}", b.getSymbolicName(), b.getBundleId()));
+            if (!toRefresh.isEmpty()) {
+                BundleLifecycleUtils.refreshBundles(toRefresh);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes[ #4851](https://github.com/Jahia/jahia-private/issues/4851)
### Description
A manual refresh of dependencies of external-provider-ui is performed at module startup to wire the module packages when the module is redeployed.

A manual refresh of a module performed while the framework is starting can easily lead to a locked state, as the framework **Start Level thread** holds the system's monitor to reach its target state. 
When an activator calls **refreshBundles** synchronously, it forces the Framework Wiring thread to attempt to stop and re-resolve bundles. 
This second thread then waits for the **Start Level thread** to release the global lock, while the Start Level thread is simultaneously waiting for the activator (and thus the refresh) to finish—resulting in a classic circular dependency deadlock.

Now the dependencies refresh do not happen at startup 

### Testing
Manual test only as the issue happen randomly at Jahia startup  
