### PR TITLE
fix: escape the mount point name used in the lookup query

### DIFF
--- a/.chachalog/X8.md
+++ b/.chachalog/X8.md
@@ -1,0 +1,5 @@
+---
+external-provider: patch
+---
+
+Escape the mount point name before using it in the JCR-SQL2 lookup query

--- a/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/service/MountPointServiceImpl.java
@@ -185,7 +185,7 @@ public class MountPointServiceImpl implements MountPointService {
     private String getMountPointQuery(String name) {
         String query = "select * from [" + Constants.JAHIANT_MOUNTPOINT + "] as mount where ischildnode('/mounts')";
         if (StringUtils.isNotEmpty(name)) {
-            query += " and ['j:nodename'] = '" + name + "'";
+            query += " and ['j:nodename'] = '" + JCRContentUtils.sqlEncode(name) + "'";
         }
         logger.debug("Query: {}", query);
         return query;

--- a/external-provider-ui/src/main/java/org/jahia/modules/external/admin/mount/MountPointsManagementFlowHandler.java
+++ b/external-provider-ui/src/main/java/org/jahia/modules/external/admin/mount/MountPointsManagementFlowHandler.java
@@ -253,7 +253,7 @@ public class MountPointsManagementFlowHandler implements Serializable {
     private String getMountPointQuery(String name) {
         String query = "select * from [" + Constants.JAHIANT_MOUNTPOINT + "] as mount where ischildnode('/mounts')";
         if (StringUtils.isNotEmpty(name)) {
-            query += (" and ['j:nodename'] = '" + name + "'");
+            query += (" and ['j:nodename'] = '" + JCRContentUtils.sqlEncode(name) + "'");
         }
         return query;
     }

--- a/tests/cypress/e2e/admin-mountPoints.cy.ts
+++ b/tests/cypress/e2e/admin-mountPoints.cy.ts
@@ -28,7 +28,7 @@ describe('VFS admin panel mount tests', () => {
             // in it must be handled safely (no query-structure error), so creation still succeeds.
             cy.visit('/cms/adminframe/default/en/settings.manageMountPoints.html?redirect=false');
             cy.get('button[data-sel-role="addMountPoint"]').click();
-            cy.get('input[name="name"]').type(`mount'test`);
+            cy.get('input[name="name"]').type('mount\'test');
             cy.get('input[name="root"]').type('/tmp/mount-test');
             cy.get('button[name="_eventId_save"]').click();
             cy.contains('Mounted');

--- a/tests/cypress/e2e/admin-mountPoints.cy.ts
+++ b/tests/cypress/e2e/admin-mountPoints.cy.ts
@@ -28,7 +28,7 @@ describe('VFS admin panel mount tests', () => {
             // in it must be handled safely (no query-structure error), so creation still succeeds.
             cy.visit('/cms/adminframe/default/en/settings.manageMountPoints.html?redirect=false');
             cy.get('button[data-sel-role="addMountPoint"]').click();
-            cy.get('input[name="name"]').type("mount'test");
+            cy.get('input[name="name"]').type(`mount'test`);
             cy.get('input[name="root"]').type('/tmp/mount-test');
             cy.get('button[name="_eventId_save"]').click();
             cy.contains('Mounted');

--- a/tests/cypress/e2e/admin-mountPoints.cy.ts
+++ b/tests/cypress/e2e/admin-mountPoints.cy.ts
@@ -23,6 +23,16 @@ describe('VFS admin panel mount tests', () => {
             cy.contains('Mounted');
             cy.contains('/mounts/mount-test');
         });
+        it('handles a mount point name containing special characters (quote) without a query error', function () {
+            // The name is used to look the mount point up via a JCR-SQL2 query; special characters
+            // in it must be handled safely (no query-structure error), so creation still succeeds.
+            cy.visit('/cms/adminframe/default/en/settings.manageMountPoints.html?redirect=false');
+            cy.get('button[data-sel-role="addMountPoint"]').click();
+            cy.get('input[name="name"]').type("mount'test");
+            cy.get('input[name="root"]').type('/tmp/mount-test');
+            cy.get('button[name="_eventId_save"]').click();
+            cy.contains('Mounted');
+        });
         it('can create a local mountpoint', function () {
             cy.visit('/cms/adminframe/default/en/settings.manageMountPoints.html?redirect=false');
             cy.get('button[data-sel-role="addMountPoint"]').click();


### PR DESCRIPTION
### Summary
`getMountPointQuery(name)` builds a JCR-SQL2 query by concatenating the mount-point `name` directly into a `['j:nodename'] = '…'` clause (in both `MountPointServiceImpl` and the admin `MountPointsManagementFlowHandler`). A name containing a single quote therefore altered the query structure (and raised a query error), so mount-point lookup by name was not robust to special characters.

### Change
Escape the `name` with `JCRContentUtils.sqlEncode(...)` before it is concatenated into the query, in both `getMountPointQuery` methods. Lookups now handle any name safely.

### Verification
Deploy-tested on a local 8.2.x instance via the `MountPointService`: a name containing a single quote previously raised an `InvalidQueryException` (broken query structure); after the change the lookup completes normally (returns no match for a non-existent name). A regression assertion is added to `tests/cypress/e2e/admin-mountPoints.cy.ts` (a mount-point name with a quote is created without a query error).
