### PR TITLE
fix: render the mount-points and provider administration screens only for server administrators

### DIFF
--- a/.chachalog/O82qTfgK.md
+++ b/.chachalog/O82qTfgK.md
@@ -1,0 +1,5 @@
+---
+external-provider: patch
+---
+
+Render the mount-points and provider administration screens only for server administrators

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
@@ -1,0 +1,13 @@
+# This screen is an ordinary, instantiable content type, so the server administration container it was
+# designed for is not the only place it can be rendered from. The permission requirement is declared on the
+# settings template that hosts it (j:applyOn=jnt:globalSettings, j:requiredPermissionNames=adminRoles) and is
+# therefore a property of that template: rendered through any other resource — a plain page content area —
+# the component carries no requirement at all, and the web flow behind it is handed to whoever can render
+# that resource. Declaring it here makes the requirement a property of the component, on every render path.
+# It propagates to every view variant of the nodetype through the view's default properties.
+#
+# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what the
+# server-administrator role grants, whereas a module-contributed permission resolves to false
+# indistinguishably from a denial on an instance where it is not registered — which would fail closed for
+# administrators too. The finer requirement still applies on the administration route via the template.
+requirePermissions=admin

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
@@ -1,13 +1,10 @@
-# This screen is an ordinary, instantiable content type, so the server administration container it was
-# designed for is not the only place it can be rendered from. The permission requirement is declared on the
-# settings template that hosts it (j:applyOn=jnt:globalSettings, j:requiredPermissionNames=adminRoles) and is
-# therefore a property of that template: rendered through any other resource — a plain page content area —
-# the component carries no requirement at all, and the web flow behind it is handed to whoever can render
-# that resource. Declaring it here makes the requirement a property of the component, on every render path.
-# It propagates to every view variant of the nodetype through the view's default properties.
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
 #
-# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what the
-# server-administrator role grants, whereas a module-contributed permission resolves to false
-# indistinguishably from a denial on an instance where it is not registered — which would fail closed for
-# administrators too. The finer requirement still applies on the administration route via the template.
+# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what
+# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
+# instance resolves to false — which would fail closed for administrators too. The finer requirement still
+# applies on the administration route via the template.
 requirePermissions=admin

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
@@ -1,0 +1,13 @@
+# This screen is an ordinary, instantiable content type, so the server administration container it was
+# designed for is not the only place it can be rendered from. The permission requirement is declared on the
+# settings template that hosts it (j:applyOn=jnt:globalSettings, j:requiredPermissionNames=adminMountPoints) and is
+# therefore a property of that template: rendered through any other resource — a plain page content area —
+# the component carries no requirement at all, and the web flow behind it is handed to whoever can render
+# that resource. Declaring it here makes the requirement a property of the component, on every render path.
+# It propagates to every view variant of the nodetype through the view's default properties.
+#
+# `admin` rather than the finer `adminMountPoints`: `admin` ships in core (root-permissions.xml) and is what the
+# server-administrator role grants, whereas a module-contributed permission resolves to false
+# indistinguishably from a denial on an instance where it is not registered — which would fail closed for
+# administrators too. The finer requirement still applies on the administration route via the template.
+requirePermissions=admin

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
@@ -1,13 +1,10 @@
-# This screen is an ordinary, instantiable content type, so the server administration container it was
-# designed for is not the only place it can be rendered from. The permission requirement is declared on the
-# settings template that hosts it (j:applyOn=jnt:globalSettings, j:requiredPermissionNames=adminMountPoints) and is
-# therefore a property of that template: rendered through any other resource — a plain page content area —
-# the component carries no requirement at all, and the web flow behind it is handed to whoever can render
-# that resource. Declaring it here makes the requirement a property of the component, on every render path.
-# It propagates to every view variant of the nodetype through the view's default properties.
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
 #
-# `admin` rather than the finer `adminMountPoints`: `admin` ships in core (root-permissions.xml) and is what the
-# server-administrator role grants, whereas a module-contributed permission resolves to false
-# indistinguishably from a denial on an instance where it is not registered — which would fail closed for
-# administrators too. The finer requirement still applies on the administration route via the template.
+# `admin` rather than the finer `adminMountPoints`: `admin` ships in core (root-permissions.xml) and is what
+# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
+# instance resolves to false — which would fail closed for administrators too. The finer requirement still
+# applies on the administration route via the template.
 requirePermissions=admin


### PR DESCRIPTION
## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. The mount-points and external-provider administration screens are ordinary, instantiable content types, so the requirement is made a property of each component. The sibling `jnt:vfsPointFactoryForm` in this same repository already carries exactly this property; these two were simply never given it.

## Change

One view property per node type, `requirePermissions=admin`, next to the flow view. Core's
`TemplatePermissionCheckFilter` enforces it before the view runs, and it propagates to every view variant of
the node type via the default view's properties — so each `settingsBootstrap3GoogleMaterialStyle` variant is
covered by the same file. Same mechanism and same one-line shape as `external-provider/vfs`'s existing
`vfsPointFactoryForm.properties`.

`admin` rather than the finer per-screen permissions (`adminMountPoints`, `adminRoles`): `admin` ships in core
(`root-permissions.xml`) and is what the `server-administrator` role grants, whereas a module-contributed
permission that isn't registered on an instance resolves to `false` — which would fail closed for
administrators too. The finer requirement still applies on the administration route via the template, so this
is an additional condition and never a replacement.

## Verification

Measured on 8.2.4.0-SNAPSHOT. Permission enforcement for the equivalent screen, counting the Spring WebFlow
execution keys a render serves (without one there is no flow to drive):

| caller | flow served |
|---|---|
| `root` | yes |
| server administrator | yes |
| administrator of one site | no |
| ordinary editor | no |

Controls, so the negatives mean what they say: every caller in the table can read the hosting page (HTTP 200),
so a "no" is a permission decision and not an unreadable node; and `root` cannot be refused by this mechanism
at all, since core short-circuits permission checks for administrators, so `root` is not a discriminating
subject.

These particular node types were not exercised on the test instance (their module is not in that lab's deployed set), so the evidence above is for the mechanism rather than for each screen. The change is declarative and identical in shape.

## Notes

- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this property
  does not. A template developer previewing one of these components in studio without an administration
  permission will get an empty fragment.
