### PR TITLE
fix: render settings components only for callers administering the resource

### DIFF
--- a/core/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
+++ b/core/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
@@ -1,0 +1,10 @@
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
+#
+# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what
+# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
+# instance resolves to false — which would fail closed for administrators too. The finer requirement still
+# applies on the administration route via the template.
+requirePermissions=admin

--- a/core/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
+++ b/core/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
@@ -1,0 +1,10 @@
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
+#
+# `admin` rather than the finer `adminMountPoints`: `admin` ships in core (root-permissions.xml) and is what
+# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
+# instance resolves to false — which would fail closed for administrators too. The finer requirement still
+# applies on the administration route via the template.
+requirePermissions=admin


### PR DESCRIPTION
## Summary

Ports the development line's condition to this maintenance line. The permission requirement belongs on the
**component**, not only on the settings template that normally hosts it: a component's access rule should
travel with the component and hold on every render path, regardless of where it is placed.

## Change

`requirePermissions=admin` on the component's **default view** properties. `TemplatePermissionCheckFilter`
enforces it before the view runs, and it propagates to every view variant via the default view.

`admin` rather than a finer per-screen permission: `admin` ships in core (`root-permissions.xml`) and is what
the `server-administrator` role grants, whereas a module-contributed permission that is not registered on an
instance resolves to `false` — which would fail closed for administrators too. The finer requirement still
applies on the administration route via the template, so this is an additional condition, never a
replacement.

## Verification — what was and was not done

The mechanism is verified on the development line, where the identical condition was measured refusing a
low-privilege and an anonymous caller while administrators kept access (the no-over-blocking control).

**Not verified on this line** — not built or deployed here. The functional check is one render of the screen
as a server administrator (must still work) and as an ordinary editor (must render nothing).

## Why this line

Requested so the condition is installable on the supported patch lines; the development-line build's
`Jahia-Required-Version` is too high to install there.
