### PR TITLE
fix: require each provider screen's own permission rather than the aggregate one

### DIFF
--- a/.chachalog/O82qTfgK.md
+++ b/.chachalog/O82qTfgK.md
@@ -2,4 +2,4 @@
 external-provider: patch
 ---
 
-Render the mount-points and provider administration screens only for server administrators
+Render the mount-points and provider administration screens for the administrators their settings templates require.

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsExternalProviders/html/serverSettingsExternalProviders.properties
@@ -3,8 +3,19 @@
 # regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
 # and it propagates to every view variant via the default view's properties.
 #
-# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what
-# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
-# instance resolves to false — which would fail closed for administrators too. The finer requirement still
-# applies on the administration route via the template.
-requirePermissions=admin
+# `adminRoles` is what this screen's own hosting templates declare (`j:requiredPermissionNames` on
+# `external-provider` and `external-provider-jahia-anthracite`), so the component and the template now state
+# the same requirement. `adminRoles` is registered by `rolesmanager` as a child of the core `admin`
+# permission, and Jahia aggregation runs downwards only: a role granted `admin` therefore still holds
+# `adminRoles`, while a role narrowed to the screens it administers keeps this one. Requiring the aggregate
+# `admin` here would refuse that narrowed role a screen its own template grants.
+#
+# `adminRoles` reads oddly for a provider screen, and it may have been copied from the roles screen. It is
+# what the template declares and what core already enforces, so this file follows it rather than choosing a
+# different requirement. If the template is wrong, both belong in the same later change.
+#
+# This module does not own `adminRoles`, and it does not declare a dependency on the module that does. That
+# adds no risk here, because the hosting templates already require the same permission and core enforces
+# that before this view runs: with `rolesmanager` absent the permission is unregistered and the screen is
+# already refused, whatever this file says.
+requirePermissions=adminRoles

--- a/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
+++ b/external-provider-ui/src/main/resources/jnt_serverSettingsManageMountPoints/html/serverSettingsManageMountPoints.properties
@@ -3,8 +3,15 @@
 # regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
 # and it propagates to every view variant via the default view's properties.
 #
-# `admin` rather than the finer `adminMountPoints`: `admin` ships in core (root-permissions.xml) and is what
-# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
-# instance resolves to false — which would fail closed for administrators too. The finer requirement still
-# applies on the administration route via the template.
-requirePermissions=admin
+# `adminMountPoints` is what this screen's own hosting templates declare (`j:requiredPermissionNames` on
+# `manageMountPoints` and `manageMountPoints-jahia-anthracite`), so the component and the template now state
+# the same requirement. `adminMountPoints` is registered by `serverSettings` as a child of the core `admin`
+# permission, and Jahia aggregation runs downwards only: a role granted `admin` therefore still holds
+# `adminMountPoints`, while a role narrowed to the screens it administers keeps this one. Requiring the
+# aggregate `admin` here would refuse that narrowed role a screen its own template grants.
+#
+# This module does not own `adminMountPoints`, and it does not declare a dependency on the module that does.
+# That adds no risk here, because the hosting templates already require the same permission and core
+# enforces that before this view runs: with `serverSettings` absent the permission is unregistered and the
+# screen is already refused, whatever this file says.
+requirePermissions=adminMountPoints


### PR DESCRIPTION
## Summary

The two administration screens in this module require the permissions their own settings templates declare, instead of the aggregate `admin`.

| Screen | Now requires | Declared by the templates |
|---|---|---|
| Manage mount points | `adminMountPoints` | `manageMountPoints`, `manageMountPoints-jahia-anthracite` |
| External providers | `adminRoles` | `external-provider`, `external-provider-jahia-anthracite` |

## Why

`requirePermissions` on the view is read by `TemplatePermissionCheckFilter` before the view runs, and it applies on every render path. That part is unchanged.

The value was the problem. Jahia permission aggregation runs downwards only: a grant of `admin` implies `adminMountPoints`, but a role that names `adminMountPoints` does not hold `admin`. The role editor exposes those child permissions one by one. A server-administration role narrowed to the screens it administers was therefore refused both screens. The hosting templates grant those screens, so the component was stricter than the template it sits in.

The comment in both files gave a reason for choosing `admin`. A module-contributed permission that is not registered on an instance resolves to `false`, and that would fail closed for administrators too. The reason does not survive contact with the templates. Both templates already declare the finer permission, and core enforces the template requirement before this view runs. If the owning module were absent, the permission would be unregistered and the screen would already be refused today, whatever these files say. The change therefore adds no dependency that the screens did not already have.

This module owns neither permission, and it declares no dependency on the modules that do: `adminMountPoints` comes from `serverSettings` and `adminRoles` from `rolesmanager`. That is worth knowing, but it is a pre-existing property of the templates rather than something introduced here.

## One oddity to flag

`adminRoles` reads oddly as the requirement for a provider screen, and it may have been copied from the roles screen. It is what the template declares and what core already enforces. This change therefore makes the component agree with the template, rather than pick a different requirement. If the template is wrong, the template and this file should change together in a later change.

## Change

One value in each of two view properties files. The comments above them record why the per-screen permission is correct, and why the missing-permission argument does not apply.

## Manual validation before vs after

The Cypress suite covers the mount points screen in `admin-mountPoints.cy.ts`, but it drives the screen as `root`, and root bypasses permission checks. The suite therefore passes either way and does not cover the case this change fixes. Run the procedure below for that case.

Prerequisites:

- Narrow a server-administration role to one screen's permission. Untick the aggregate `admin`, then tick `administrationAccess` and `adminMountPoints`. Read the role back: `j:permissionNames` must list `adminMountPoints` and must not list `admin`.
- Use an account that holds that role at the repository root.

Procedure: as that account, open Administration and then Mount points, at `/cms/adminframe/default/en/settings.manageMountPoints.html`.

Expected on this branch: the mount points screen renders. Expected on the base branch: the screen is empty, although the caller holds `adminMountPoints`, which is what the hosting template declares.

## Verification

- The change is data only, so there is nothing to compile.
- Both hosting templates for each screen declare the permission this change adopts.
- Core evaluates `requirePermissions` with `node.hasPermission(perm)` on the component node, which lives under `/modules/`. A role granted at the repository root holds its permissions there by inheritance, so the finer permission resolves for the narrowed role.
- These are the only two view properties files in the module that set `requirePermissions`.
- `admin-mountPoints.cy.ts` drives the screen as `root`, so it is unaffected by the change.

## Changelog

The pending fragment for these screens is amended in place. A second fragment would put two entries for one behaviour in the same release notes, and the older entry describes behaviour that never shipped.
