### PR TITLE
fix: resolve a VFS mount point root against the local file system

### DIFF
--- a/.chachalog/Jj6T3.md
+++ b/.chachalog/Jj6T3.md
@@ -2,4 +2,8 @@
 external-provider: patch
 ---
 
-Restricted the root path of a VFS mount point to the local file system. A mount point whose root names another scheme stops working; to keep it, add that scheme to `vfsMountPoint.allowedSchemes` in the `org.jahia.modules.external.vfs` configuration. A change to that set reaches the mount points already mounted, without a restart: adding a scheme puts such a mount point back to work, and removing one stops it. The mount point mutations under `admin.jahia.mountPoint` now declare the permission they require, so a `permission.GqlMountPointMutation.*` key set in `org.jahia.modules.graphql.provider.cfg` no longer applies to them.
+Restricted the root path of a VFS mount point to the local file system.
+
+A VFS mount point whose root path names any other scheme stops working. To check whether you are affected, read the root path of each VFS mount point: one that starts with a scheme other than `file://` is affected, and a plain path is not. To keep such a mount point working, list the schemes its root may name in the `vfsMountPoint.allowedSchemes` property of the `org.jahia.modules.external.vfs` configuration, as a comma-separated list — for example `file,sftp`. The local file system alone is the default. The property reaches the mount points already mounted, so a mount point serves again as soon as its scheme is listed, and stops when the scheme is taken off the list, without restarting the instance.
+
+The mount point operations of the GraphQL administration API are granted by the `graphqlAdminMutation` and `graphqlAdminQuery` permissions. A permission set for one of these operations in the `org.jahia.modules.graphql.provider` configuration is not read. If you had set one of the `permission.Gql*MountPoint*` keys there, grant `graphqlAdminMutation` or `graphqlAdminQuery` to the roles that need these operations instead.

--- a/.chachalog/Jj6T3.md
+++ b/.chachalog/Jj6T3.md
@@ -1,0 +1,5 @@
+---
+external-provider: patch
+---
+
+Restricted the root path of a VFS mount point to the local file system. A mount point whose root names another scheme stops working after the upgrade; to keep it, add that scheme to `vfsMountPoint.allowedSchemes` in the `org.jahia.modules.external.vfs` configuration.

--- a/.chachalog/Jj6T3.md
+++ b/.chachalog/Jj6T3.md
@@ -2,4 +2,4 @@
 external-provider: patch
 ---
 
-Restricted the root path of a VFS mount point to the local file system. A mount point whose root names another scheme stops working after the upgrade; to keep it, add that scheme to `vfsMountPoint.allowedSchemes` in the `org.jahia.modules.external.vfs` configuration.
+Restricted the root path of a VFS mount point to the local file system. A mount point whose root names another scheme stops working; to keep it, add that scheme to `vfsMountPoint.allowedSchemes` in the `org.jahia.modules.external.vfs` configuration. A change to that set reaches the mount points already mounted, without a restart: adding a scheme puts such a mount point back to work, and removing one stops it. The mount point mutations under `admin.jahia.mountPoint` now declare the permission they require, so a `permission.GqlMountPointMutation.*` key set in `org.jahia.modules.graphql.provider.cfg` no longer applies to them.

--- a/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointMutation.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointMutation.java
@@ -32,6 +32,7 @@ import org.jahia.modules.external.service.MountPoint;
 import org.jahia.modules.external.service.MountPointService;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
@@ -46,6 +47,7 @@ public class GqlMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Create a mounted mount point node in /mounts")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public String add(
             @GraphQLName("name") @GraphQLDescription("Mount point name") @GraphQLNonNull String name,
             @GraphQLName("mountPointRefPath") @GraphQLDescription("Target local mount point") String mountPointRefPath
@@ -56,6 +58,7 @@ public class GqlMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Modify an existing mount point node")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public boolean modify(
             @GraphQLName("pathOrId") @GraphQLDescription("Mount point path or ID to modify") @GraphQLNonNull String pathOrId,
             @GraphQLName("name") @GraphQLDescription("Rename existing mount point") String name,
@@ -72,6 +75,7 @@ public class GqlMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Mount an existing mount point")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public boolean mount(
             @GraphQLName("pathOrId") @GraphQLDescription("Mount point path or ID to mount") @GraphQLNonNull String pathOrId
     ) throws RepositoryException {
@@ -80,6 +84,7 @@ public class GqlMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Unmount an existing mount point")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public boolean unmount(
             @GraphQLName("pathOrId") @GraphQLDescription("Mount point path or ID to unmount") @GraphQLNonNull String pathOrId
     ) throws RepositoryException {

--- a/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointQuery.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/GqlMountPointQuery.java
@@ -30,6 +30,7 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import org.jahia.modules.external.service.MountPoint;
 import org.jahia.modules.external.service.MountPointService;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
@@ -46,6 +47,7 @@ public class GqlMountPointQuery {
 
     @GraphQLField
     @GraphQLDescription("Get list of mount points, or empty list if no mounts exist")
+    @GraphQLRequiresPermission(value = "graphqlAdminQuery")
     public List<GqlMountPoint> getMountPoints() throws RepositoryException {
         return mountPointService.getMountPoints().stream()
                 .map(GqlMountPoint::new)
@@ -54,6 +56,7 @@ public class GqlMountPointQuery {
 
     @GraphQLField
     @GraphQLDescription("Get mount point with given name, or null if it doesn't exists")
+    @GraphQLRequiresPermission(value = "graphqlAdminQuery")
     public GqlMountPoint getMountPoint(
             @GraphQLName("name") @GraphQLDescription("Name for the mount point") @GraphQLNonNull String name
     ) throws RepositoryException {

--- a/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminMutationExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminMutationExtension.java
@@ -28,6 +28,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminMutation;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 @GraphQLTypeExtension(GqlJahiaAdminMutation.class)
 @GraphQLDescription("Mutation extensions for mount point")
@@ -36,6 +37,7 @@ public class JahiaAdminMutationExtension {
     @GraphQLField
     @GraphQLName("mountPoint")
     @GraphQLDescription("Mount point mutation extension API")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public static GqlMountPointMutation mountPoint() {
         return new GqlMountPointMutation();
     }

--- a/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminQueryExtension.java
+++ b/core/src/main/java/org/jahia/modules/external/graphql/JahiaAdminQueryExtension.java
@@ -27,7 +27,6 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
-import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminQuery;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlJahiaAdminQuery;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
@@ -38,6 +37,7 @@ public class JahiaAdminQueryExtension {
     @GraphQLField
     @GraphQLName("mountPoint")
     @GraphQLDescription("Mount point query extension API")
+    @GraphQLRequiresPermission(value = "graphqlAdminQuery")
     public static GqlMountPointQuery mountPoint() {
         return new GqlMountPointQuery();
     }

--- a/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
@@ -1,5 +1,10 @@
 const LOCAL_ROOT = '/tmp/mount-test';
 const LOCAL_GZIP = `${LOCAL_ROOT}/archive.gz`;
+const LOCAL_FILE = 'index.html';
+
+// A scheme that names neither the local file system nor the layer over it, so a set holding it alone answers for
+// no root this suite mounts. Nothing is opened towards it: a root is refused before it is resolved.
+const UNRELATED_SCHEME = 'sftp';
 
 // A root that answers only to the configured set: the gzip provider is a scheme of its own, layered over a local
 // file, so the probe reaches nothing off this machine. A root naming a remote scheme would answer the same
@@ -35,7 +40,15 @@ const clearAllowedSchemes = () => cy.apollo({
     errorPolicy: 'all'
 });
 
+const readNode = (path: string) => cy.apollo({
+    queryFile: 'getVfsNode.graphql',
+    variables: {path},
+    errorPolicy: 'all'
+});
+
 const wasAccepted = response => !response.errors || response.errors.length === 0;
+
+const wasServed = response => Boolean(response.data?.jcr?.nodeByPath);
 
 /**
  * Probes the configured root until it is answered as expected, so the test reads the set back rather than assume
@@ -51,6 +64,22 @@ const expectConfiguredRoot = (accepted: boolean) => {
             timeout: ARRIVAL_TIMEOUT,
             interval: ARRIVAL_INTERVAL,
             errorMsg: `${CONFIGURED_ROOT} is still ${accepted ? 'refused' : 'accepted'}`
+        }
+    );
+};
+
+/**
+ * Reads a file of a mount point until the answer is the expected one, so the test reads whether the mount point
+ * still serves rather than assume the set has arrived.
+ */
+const expectServed = (name: string, served: boolean) => {
+    const path = `/mounts/${name}/${LOCAL_FILE}`;
+    return cy.waitUntil(
+        () => readNode(path).then(response => wasServed(response) === served),
+        {
+            timeout: ARRIVAL_TIMEOUT,
+            interval: ARRIVAL_INTERVAL,
+            errorMsg: `${path} is still ${served ? 'not served' : 'served'}`
         }
     );
 };
@@ -107,5 +136,21 @@ describe('VFS mount point allowed root schemes', () => {
         clearAllowedSchemes();
 
         expectConfiguredRoot(false);
+    });
+
+    /**
+     * A mount point reads the set on every lookup, so the configuration reaches the mount points already mounted:
+     * a set that stops naming the scheme of a root stops the mount point serving it, and naming it again puts the
+     * mount point back to work. Neither needs the instance restarted.
+     */
+    it('stops serving a mount point whose root scheme the configuration stops naming', function () {
+        addVfs('scheme-served', LOCAL_ROOT);
+        expectServed('scheme-served', true);
+
+        setAllowedSchemes(UNRELATED_SCHEME);
+        expectServed('scheme-served', false);
+
+        clearAllowedSchemes();
+        expectServed('scheme-served', true);
     });
 });

--- a/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
@@ -8,6 +8,10 @@ const LOCAL_GZIP = `${LOCAL_ROOT}/archive.gz`;
 const CONFIGURED_ROOT = `gz:file://${LOCAL_GZIP}`;
 const CONFIGURED_SCHEMES = 'file,gz';
 
+// The same layered scheme over a root that is not on this machine. Naming the layer does not name what the layer
+// reaches, so this stays refused and no connection is opened from wherever the suite runs.
+const LAYERED_REMOTE_ROOT = 'gz:http://localhost:8080/';
+
 // The configured set reaches the module asynchronously, so a probe is retried until it answers. Bounded by time
 // rather than by attempts: what is being waited for is a delivery, not a number of round trips.
 const ARRIVAL_TIMEOUT = 10000;
@@ -83,6 +87,16 @@ describe('VFS mount point allowed root schemes', () => {
 
         addVfs('scheme-local', LOCAL_ROOT).should(response => {
             expect(response.data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
+        });
+    });
+
+    it('refuses a configured layered scheme over a root it does not name', function () {
+        setAllowedSchemes(CONFIGURED_SCHEMES);
+        expectConfiguredRoot(true);
+
+        addVfs('scheme-layered', LAYERED_REMOTE_ROOT, 'all').should(response => {
+            expect(response.errors, `expected ${LAYERED_REMOTE_ROOT} to be refused`).to.not.be.empty;
+            expect(response.errors.map(e => e.message).join(' ')).to.contain(LAYERED_REMOTE_ROOT);
         });
     });
 

--- a/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
@@ -1,8 +1,17 @@
 const LOCAL_ROOT = '/tmp/mount-test';
+const LOCAL_GZIP = `${LOCAL_ROOT}/archive.gz`;
 
-// A root reaching off the local file system, so it answers only to the configured set
-const CONFIGURED_ROOT = 'https://example.com/';
-const CONFIGURED_SCHEMES = 'file,https';
+// A root that answers only to the configured set: the gzip provider is a scheme of its own, layered over a local
+// file, so the probe reaches nothing off this machine. A root naming a remote scheme would answer the same
+// question and open a real connection from wherever the suite runs. No other suite names this scheme, so
+// widening it here cannot make a case elsewhere read against a set this one configured.
+const CONFIGURED_ROOT = `gz:file://${LOCAL_GZIP}`;
+const CONFIGURED_SCHEMES = 'file,gz';
+
+// The configured set reaches the module asynchronously, so a probe is retried until it answers. Bounded by time
+// rather than by attempts: what is being waited for is a delivery, not a number of round trips.
+const ARRIVAL_TIMEOUT = 10000;
+const ARRIVAL_INTERVAL = 250;
 
 const addVfs = (name: string, rootPath: string, errorPolicy?: 'all') => cy.apollo({
     mutationFile: 'addVfsJahiaPath.graphql',
@@ -25,18 +34,22 @@ const clearAllowedSchemes = () => cy.apollo({
 const wasAccepted = response => !response.errors || response.errors.length === 0;
 
 /**
- * The configured set reaches the module through the configuration service, so read the answer back rather than
- * assume it has arrived. Each attempt is a round trip, which is the wait.
+ * Probes the configured root until it is answered as expected, so the test reads the set back rather than assume
+ * it has arrived. Only the probe that is answered as expected creates a mount point, which the cleanup between
+ * cases removes.
  */
-const expectConfiguredRoot = (accepted: boolean, attempt = 1) =>
-    addVfs(`scheme-probe-${attempt}`, CONFIGURED_ROOT, 'all').then(response => {
-        if (wasAccepted(response) === accepted) {
-            return cy.wrap(response);
+const expectConfiguredRoot = (accepted: boolean) => {
+    let attempt = 0;
+    return cy.waitUntil(
+        () => addVfs(`scheme-probe-${++attempt}`, CONFIGURED_ROOT, 'all')
+            .then(response => wasAccepted(response) === accepted),
+        {
+            timeout: ARRIVAL_TIMEOUT,
+            interval: ARRIVAL_INTERVAL,
+            errorMsg: `${CONFIGURED_ROOT} is still ${accepted ? 'refused' : 'accepted'}`
         }
-
-        expect(attempt, `${CONFIGURED_ROOT} is still ${accepted ? 'refused' : 'accepted'}`).to.be.lessThan(10);
-        return expectConfiguredRoot(accepted, attempt + 1);
-    });
+    );
+};
 
 describe('VFS mount point allowed root schemes', () => {
     before(function () {
@@ -46,6 +59,7 @@ describe('VFS mount point allowed root schemes', () => {
     beforeEach(function () {
         cy.executeGroovy('cleanup.groovy');
         cy.executeGroovy('createDir.groovy');
+        cy.executeGroovy('createVfsGzip.groovy', {'#path#': LOCAL_GZIP});
     });
 
     after(function () {

--- a/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root-schemes.cy.ts
@@ -1,0 +1,83 @@
+const LOCAL_ROOT = '/tmp/mount-test';
+
+// A root reaching off the local file system, so it answers only to the configured set
+const CONFIGURED_ROOT = 'https://example.com/';
+const CONFIGURED_SCHEMES = 'file,https';
+
+const addVfs = (name: string, rootPath: string, errorPolicy?: 'all') => cy.apollo({
+    mutationFile: 'addVfsJahiaPath.graphql',
+    variables: {name, rootPath},
+    errorPolicy
+});
+
+const setAllowedSchemes = (value: string) => cy.apollo({
+    mutationFile: 'setVfsAllowedSchemes.graphql',
+    variables: {value}
+});
+
+// Also run before the suite, so a run that ended without reaching its own cleanup does not leave the
+// set widened for whatever runs next
+const clearAllowedSchemes = () => cy.apollo({
+    mutationFile: 'clearVfsAllowedSchemes.graphql',
+    errorPolicy: 'all'
+});
+
+const wasAccepted = response => !response.errors || response.errors.length === 0;
+
+/**
+ * The configured set reaches the module through the configuration service, so read the answer back rather than
+ * assume it has arrived. Each attempt is a round trip, which is the wait.
+ */
+const expectConfiguredRoot = (accepted: boolean, attempt = 1) =>
+    addVfs(`scheme-probe-${attempt}`, CONFIGURED_ROOT, 'all').then(response => {
+        if (wasAccepted(response) === accepted) {
+            return cy.wrap(response);
+        }
+
+        expect(attempt, `${CONFIGURED_ROOT} is still ${accepted ? 'refused' : 'accepted'}`).to.be.lessThan(10);
+        return expectConfiguredRoot(accepted, attempt + 1);
+    });
+
+describe('VFS mount point allowed root schemes', () => {
+    before(function () {
+        clearAllowedSchemes();
+    });
+
+    beforeEach(function () {
+        cy.executeGroovy('cleanup.groovy');
+        cy.executeGroovy('createDir.groovy');
+    });
+
+    after(function () {
+        clearAllowedSchemes();
+        cy.executeGroovy('cleanup.groovy');
+    });
+
+    it('refuses a scheme the configuration does not name', function () {
+        expectConfiguredRoot(false);
+    });
+
+    it('accepts a scheme the configuration names', function () {
+        setAllowedSchemes(CONFIGURED_SCHEMES);
+
+        expectConfiguredRoot(true);
+    });
+
+    it('keeps serving the local file system alongside a configured scheme', function () {
+        setAllowedSchemes(CONFIGURED_SCHEMES);
+        expectConfiguredRoot(true);
+
+        addVfs('scheme-local', LOCAL_ROOT).should(response => {
+            expect(response.data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
+        });
+    });
+
+    it('refuses the scheme again once the configuration stops naming it', function () {
+        setAllowedSchemes(CONFIGURED_SCHEMES);
+        expectConfiguredRoot(true);
+
+        clearAllowedSchemes();
+
+        expectConfiguredRoot(false);
+    });
+});

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -51,6 +51,13 @@ const readNode = (path: string) => cy.apollo({queryFile: 'getVfsNode.graphql', v
 
 const readMountInfo = (name: string) => cy.apollo({queryFile: 'mountInfo.graphql', variables: {name}});
 
+// A refused root is reported by the repository, which flips the mount status after the mutation has answered, so
+// the status is read until it changes rather than once.
+const expectNotMounted = (name: string) => cy.waitUntil(
+    () => readMountInfo(name).then(({data}) => data.admin.mountPoint.mountPoint.mountStatus !== 'mounted'),
+    {timeout: 10000, interval: 250, errorMsg: `${name} is still mounted`}
+);
+
 const storeRootOf = (uuid: string, rootPath: string) => cy.executeGroovy('setVfsRootPath.groovy', {
     '#uuid#': uuid,
     '#rootPath#': rootPath
@@ -106,6 +113,7 @@ describe('VFS mount point root path', () => {
             .then(uuid => storeRootOf(uuid, UNSUPPORTED_ROOT).then(() => mount(uuid)));
 
         readNode('/mounts/root-alongside/images/tomcat.gif').should(expectNamed('tomcat.gif'));
+        expectNotMounted('root-stored');
     });
 
     it('leaves the supported root in place when the change is refused', function () {

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -62,8 +62,6 @@ const mount = (uuid: string) => cy.apollo({
     errorPolicy: 'all'
 });
 
-const expectNotMounted = ({data}) => expect(data.admin.mountPoint.mountPoint.mountStatus).to.not.eq('mounted');
-
 describe('VFS mount point root path', () => {
     beforeEach(function () {
         cy.executeGroovy('cleanup.groovy');
@@ -91,7 +89,7 @@ describe('VFS mount point root path', () => {
 
     UNSUPPORTED_ROOTS.forEach((rootPath, index) => {
         it(`refuses an unsupported root on creation: ${rootPath}`, function () {
-            addVfs(`root-refused-${index}`, rootPath, 'all').should(expectRefused);
+            addVfs(`root-refused-${index}`, rootPath, 'all').should(expectRefused(rootPath));
         });
     });
 
@@ -108,7 +106,6 @@ describe('VFS mount point root path', () => {
             .then(uuid => storeRootOf(uuid, UNSUPPORTED_ROOT).then(() => mount(uuid)));
 
         readNode('/mounts/root-alongside/images/tomcat.gif').should(expectNamed('tomcat.gif'));
-        readMountInfo('root-stored').should(expectNotMounted);
     });
 
     it('leaves the supported root in place when the change is refused', function () {

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -1,0 +1,96 @@
+const LOCAL_ROOT = '/tmp/mount-test';
+const LOCAL_ARCHIVE = `${LOCAL_ROOT}/archive.zip`;
+
+// Roots naming a scheme a mount point does not support: each names a location off the local file
+// system, or layers another provider over one that does. Schemes needing a server to answer (ftp,
+// sftp, smb) are deliberately absent — a root using one fails for want of a server, whatever the
+// scheme rule says, so a case on it would assert nothing.
+const UNSUPPORTED_ROOTS = [
+    'http://localhost:8080/',
+    'https://example.com/',
+    `zip:file://${LOCAL_ARCHIVE}`,
+    `jar:file://${LOCAL_ARCHIVE}`
+];
+
+const addVfs = (name: string, rootPath: string, errorPolicy?: 'all') => cy.apollo({
+    mutationFile: 'addVfsJahiaPath.graphql',
+    variables: {name, rootPath},
+    errorPolicy
+});
+
+describe('VFS mount point root path', () => {
+    beforeEach(function () {
+        cy.executeGroovy('cleanup.groovy');
+        cy.executeGroovy('createDir.groovy');
+        cy.executeGroovy('createVfsArchive.groovy', {'#path#': LOCAL_ARCHIVE});
+    });
+
+    afterEach(function () {
+        cy.executeGroovy('cleanup.groovy');
+    });
+
+    describe('a supported root', () => {
+        it('is accepted as a plain file system path', function () {
+            addVfs('root-plain', LOCAL_ROOT).should(({data}) => {
+                expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
+            });
+        });
+
+        it('is accepted with the file scheme', function () {
+            addVfs('root-file-scheme', `file://${LOCAL_ROOT}`).should(({data}) => {
+                expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
+            });
+        });
+
+        it('serves the mounted content', function () {
+            addVfs('root-served', LOCAL_ROOT);
+            cy.apollo({
+                queryFile: 'getVfsNode.graphql',
+                variables: {path: '/mounts/root-served/images/tomcat.gif'}
+            }).should(({data}) => {
+                expect(data.jcr.nodeByPath.name).to.eq('tomcat.gif');
+            });
+        });
+    });
+
+    describe('an unsupported root', () => {
+        UNSUPPORTED_ROOTS.forEach((rootPath, index) => {
+            it(`is refused on creation: ${rootPath}`, function () {
+                addVfs(`root-refused-${index}`, rootPath, 'all').should(({errors, data}) => {
+                    expect(errors, `expected ${rootPath} to be refused`).to.not.be.empty;
+                    expect(data?.admin?.jahia?.mountPoint?.addVfs).to.be.oneOf([null, undefined]);
+                });
+            });
+        });
+
+        it('is refused when it replaces a supported one', function () {
+            addVfs('root-modified', LOCAL_ROOT).then(({data}) => {
+                cy.apollo({
+                    mutationFile: 'modifyVfsJahiaPath.graphql',
+                    variables: {pathOrId: data.admin.jahia.mountPoint.addVfs, rootPath: 'https://example.com/'},
+                    errorPolicy: 'all'
+                }).should(({errors}) => {
+                    expect(errors).to.not.be.empty;
+                });
+            });
+        });
+
+        it('leaves the supported root in place when the change is refused', function () {
+            addVfs('root-unchanged', LOCAL_ROOT).then(({data}) => {
+                cy.apollo({
+                    mutationFile: 'modifyVfsJahiaPath.graphql',
+                    variables: {pathOrId: data.admin.jahia.mountPoint.addVfs, rootPath: 'https://example.com/'},
+                    errorPolicy: 'all'
+                });
+                cy.apollo({
+                    queryFile: 'mountInfo.graphql',
+                    variables: {name: 'root-unchanged'}
+                }).should(({data: info}) => {
+                    const rootPath = info.admin.mountPoint.mountPoint.properties
+                        .find(p => p.key === 'j:rootPath').value;
+                    expect(rootPath).to.eq(LOCAL_ROOT);
+                });
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -70,6 +70,12 @@ const mount = (uuid: string) => cy.apollo({
 });
 
 describe('VFS mount point root path', () => {
+    // The suite that configures the schemes a root may name sorts before this one and writes instance state, so a
+    // run of it that ends without reaching its own cleanup would leave every case here reading against its set.
+    before(function () {
+        cy.apollo({mutationFile: 'clearVfsAllowedSchemes.graphql', errorPolicy: 'all'});
+    });
+
     beforeEach(function () {
         cy.executeGroovy('cleanup.groovy');
         cy.executeGroovy('createDir.groovy');

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -1,5 +1,6 @@
 const LOCAL_ROOT = '/tmp/mount-test';
 const LOCAL_ARCHIVE = `${LOCAL_ROOT}/archive.zip`;
+const UNSUPPORTED_ROOT = 'https://example.com/';
 
 // Roots naming a scheme a mount point does not support: each names a location off the local file
 // system, or layers another provider over one that does. Schemes needing a server to answer (ftp,
@@ -7,7 +8,7 @@ const LOCAL_ARCHIVE = `${LOCAL_ROOT}/archive.zip`;
 // scheme rule says, so a case on it would assert nothing.
 const UNSUPPORTED_ROOTS = [
     'http://localhost:8080/',
-    'https://example.com/',
+    UNSUPPORTED_ROOT,
     `zip:file://${LOCAL_ARCHIVE}`,
     `jar:file://${LOCAL_ARCHIVE}`
 ];
@@ -17,6 +18,34 @@ const addVfs = (name: string, rootPath: string, errorPolicy?: 'all') => cy.apoll
     variables: {name, rootPath},
     errorPolicy
 });
+
+const setRootOf = (uuid: string, rootPath: string) => cy.apollo({
+    mutationFile: 'modifyVfsJahiaPath.graphql',
+    variables: {pathOrId: uuid, rootPath},
+    errorPolicy: 'all'
+});
+
+const uuidOf = (response): string => response.data.admin.jahia.mountPoint.addVfs;
+
+const expectAccepted = ({data}) => expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
+
+const expectRefused = ({errors, data}) => {
+    expect(errors).to.not.be.empty;
+    expect(data?.admin?.jahia?.mountPoint?.addVfs).to.be.oneOf([null, undefined]);
+};
+
+const expectErrors = ({errors}) => expect(errors).to.not.be.empty;
+
+const expectNamed = (name: string) => ({data}) => expect(data.jcr.nodeByPath.name).to.eq(name);
+
+const expectRootPath = (rootPath: string) => ({data}) => {
+    const property = data.admin.mountPoint.mountPoint.properties.find(p => p.key === 'j:rootPath');
+    expect(property.value).to.eq(rootPath);
+};
+
+const readNode = (path: string) => cy.apollo({queryFile: 'getVfsNode.graphql', variables: {path}});
+
+const readMountInfo = (name: string) => cy.apollo({queryFile: 'mountInfo.graphql', variables: {name}});
 
 describe('VFS mount point root path', () => {
     beforeEach(function () {
@@ -29,68 +58,37 @@ describe('VFS mount point root path', () => {
         cy.executeGroovy('cleanup.groovy');
     });
 
-    describe('a supported root', () => {
-        it('is accepted as a plain file system path', function () {
-            addVfs('root-plain', LOCAL_ROOT).should(({data}) => {
-                expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
-            });
-        });
+    it('accepts a supported root as a plain file system path', function () {
+        addVfs('root-plain', LOCAL_ROOT).should(expectAccepted);
+    });
 
-        it('is accepted with the file scheme', function () {
-            addVfs('root-file-scheme', `file://${LOCAL_ROOT}`).should(({data}) => {
-                expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
-            });
-        });
+    it('accepts a supported root with the file scheme', function () {
+        addVfs('root-file-scheme', `file://${LOCAL_ROOT}`).should(expectAccepted);
+    });
 
-        it('serves the mounted content', function () {
-            addVfs('root-served', LOCAL_ROOT);
-            cy.apollo({
-                queryFile: 'getVfsNode.graphql',
-                variables: {path: '/mounts/root-served/images/tomcat.gif'}
-            }).should(({data}) => {
-                expect(data.jcr.nodeByPath.name).to.eq('tomcat.gif');
-            });
+    it('serves the content of a supported root', function () {
+        addVfs('root-served', LOCAL_ROOT);
+
+        readNode('/mounts/root-served/images/tomcat.gif').should(expectNamed('tomcat.gif'));
+    });
+
+    UNSUPPORTED_ROOTS.forEach((rootPath, index) => {
+        it(`refuses an unsupported root on creation: ${rootPath}`, function () {
+            addVfs(`root-refused-${index}`, rootPath, 'all').should(expectRefused);
         });
     });
 
-    describe('an unsupported root', () => {
-        UNSUPPORTED_ROOTS.forEach((rootPath, index) => {
-            it(`is refused on creation: ${rootPath}`, function () {
-                addVfs(`root-refused-${index}`, rootPath, 'all').should(({errors, data}) => {
-                    expect(errors, `expected ${rootPath} to be refused`).to.not.be.empty;
-                    expect(data?.admin?.jahia?.mountPoint?.addVfs).to.be.oneOf([null, undefined]);
-                });
-            });
-        });
+    it('refuses an unsupported root replacing a supported one', function () {
+        addVfs('root-modified', LOCAL_ROOT)
+            .then(uuidOf)
+            .then(uuid => setRootOf(uuid, UNSUPPORTED_ROOT).should(expectErrors));
+    });
 
-        it('is refused when it replaces a supported one', function () {
-            addVfs('root-modified', LOCAL_ROOT).then(({data}) => {
-                cy.apollo({
-                    mutationFile: 'modifyVfsJahiaPath.graphql',
-                    variables: {pathOrId: data.admin.jahia.mountPoint.addVfs, rootPath: 'https://example.com/'},
-                    errorPolicy: 'all'
-                }).should(({errors}) => {
-                    expect(errors).to.not.be.empty;
-                });
-            });
-        });
+    it('leaves the supported root in place when the change is refused', function () {
+        addVfs('root-unchanged', LOCAL_ROOT)
+            .then(uuidOf)
+            .then(uuid => setRootOf(uuid, UNSUPPORTED_ROOT));
 
-        it('leaves the supported root in place when the change is refused', function () {
-            addVfs('root-unchanged', LOCAL_ROOT).then(({data}) => {
-                cy.apollo({
-                    mutationFile: 'modifyVfsJahiaPath.graphql',
-                    variables: {pathOrId: data.admin.jahia.mountPoint.addVfs, rootPath: 'https://example.com/'},
-                    errorPolicy: 'all'
-                });
-                cy.apollo({
-                    queryFile: 'mountInfo.graphql',
-                    variables: {name: 'root-unchanged'}
-                }).should(({data: info}) => {
-                    const rootPath = info.admin.mountPoint.mountPoint.properties
-                        .find(p => p.key === 'j:rootPath').value;
-                    expect(rootPath).to.eq(LOCAL_ROOT);
-                });
-            });
-        });
+        readMountInfo('root-unchanged').should(expectRootPath(LOCAL_ROOT));
     });
 });

--- a/tests/cypress/e2e/vfs-mount-root.cy.ts
+++ b/tests/cypress/e2e/vfs-mount-root.cy.ts
@@ -29,12 +29,16 @@ const uuidOf = (response): string => response.data.admin.jahia.mountPoint.addVfs
 
 const expectAccepted = ({data}) => expect(data.admin.jahia.mountPoint.addVfs).to.not.be.empty;
 
-const expectRefused = ({errors, data}) => {
-    expect(errors).to.not.be.empty;
+const expectRefused = (rootPath: string) => ({errors, data}) => {
+    expect(errors, `expected ${rootPath} to be refused`).to.not.be.empty;
+    expect(errors.map(e => e.message).join(' '), 'the reported error should name the root').to.contain(rootPath);
     expect(data?.admin?.jahia?.mountPoint?.addVfs).to.be.oneOf([null, undefined]);
 };
 
-const expectErrors = ({errors}) => expect(errors).to.not.be.empty;
+const expectRefusedChange = (rootPath: string) => ({errors}) => {
+    expect(errors, `expected ${rootPath} to be refused`).to.not.be.empty;
+    expect(errors.map(e => e.message).join(' '), 'the reported error should name the root').to.contain(rootPath);
+};
 
 const expectNamed = (name: string) => ({data}) => expect(data.jcr.nodeByPath.name).to.eq(name);
 
@@ -46,6 +50,19 @@ const expectRootPath = (rootPath: string) => ({data}) => {
 const readNode = (path: string) => cy.apollo({queryFile: 'getVfsNode.graphql', variables: {path}});
 
 const readMountInfo = (name: string) => cy.apollo({queryFile: 'mountInfo.graphql', variables: {name}});
+
+const storeRootOf = (uuid: string, rootPath: string) => cy.executeGroovy('setVfsRootPath.groovy', {
+    '#uuid#': uuid,
+    '#rootPath#': rootPath
+});
+
+const mount = (uuid: string) => cy.apollo({
+    mutationFile: 'mountVfsJahiaPath.graphql',
+    variables: {pathOrId: uuid},
+    errorPolicy: 'all'
+});
+
+const expectNotMounted = ({data}) => expect(data.admin.mountPoint.mountPoint.mountStatus).to.not.eq('mounted');
 
 describe('VFS mount point root path', () => {
     beforeEach(function () {
@@ -81,7 +98,17 @@ describe('VFS mount point root path', () => {
     it('refuses an unsupported root replacing a supported one', function () {
         addVfs('root-modified', LOCAL_ROOT)
             .then(uuidOf)
-            .then(uuid => setRootOf(uuid, UNSUPPORTED_ROOT).should(expectErrors));
+            .then(uuid => setRootOf(uuid, UNSUPPORTED_ROOT).should(expectRefusedChange(UNSUPPORTED_ROOT)));
+    });
+
+    it('leaves the other mount points serving when a stored root is not supported', function () {
+        addVfs('root-alongside', LOCAL_ROOT);
+        addVfs('root-stored', LOCAL_ROOT)
+            .then(uuidOf)
+            .then(uuid => storeRootOf(uuid, UNSUPPORTED_ROOT).then(() => mount(uuid)));
+
+        readNode('/mounts/root-alongside/images/tomcat.gif').should(expectNamed('tomcat.gif'));
+        readMountInfo('root-stored').should(expectNotMounted);
     });
 
     it('leaves the supported root in place when the change is refused', function () {

--- a/tests/cypress/fixtures/addVfsJahiaPath.graphql
+++ b/tests/cypress/fixtures/addVfsJahiaPath.graphql
@@ -1,0 +1,9 @@
+mutation addVfsJahiaPath($name: String!, $rootPath: String) {
+    admin {
+        jahia {
+            mountPoint {
+                addVfs(name: $name, rootPath: $rootPath)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/clearVfsAllowedSchemes.graphql
+++ b/tests/cypress/fixtures/clearVfsAllowedSchemes.graphql
@@ -1,0 +1,9 @@
+mutation clearVfsAllowedSchemes {
+    admin {
+        jahia {
+            configuration(pid: "org.jahia.modules.external.vfs") {
+                remove(name: "vfsMountPoint.allowedSchemes")
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/createVfsArchive.groovy
+++ b/tests/cypress/fixtures/createVfsArchive.groovy
@@ -1,0 +1,13 @@
+// Puts a real archive next to the mounted folder, so a root layering the zip/jar provider over a
+// local file resolves. Without the archive such a root fails for lack of a file, which says
+// nothing about whether the scheme itself is allowed.
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+def archive = new File('#path#')
+new ZipOutputStream(new FileOutputStream(archive)).withCloseable { zos ->
+    zos.putNextEntry(new ZipEntry('inside.txt'))
+    zos.write('inside'.getBytes('UTF-8'))
+    zos.closeEntry()
+}
+setResult(archive.exists())

--- a/tests/cypress/fixtures/createVfsArchive.groovy
+++ b/tests/cypress/fixtures/createVfsArchive.groovy
@@ -1,4 +1,4 @@
-// Puts a real archive next to the mounted folder, so a root layering the zip/jar provider over a
+// Puts a real archive inside the mounted folder, so a root layering the zip/jar provider over a
 // local file resolves. Without the archive such a root fails for lack of a file, which says
 // nothing about whether the scheme itself is allowed.
 import java.util.zip.ZipEntry

--- a/tests/cypress/fixtures/createVfsGzip.groovy
+++ b/tests/cypress/fixtures/createVfsGzip.groovy
@@ -1,0 +1,10 @@
+// Puts a real gzip file inside the mounted folder, so a root layering the gzip provider over a local file
+// resolves. Without the file such a root fails for lack of one, which says nothing about whether the scheme
+// itself is allowed.
+import java.util.zip.GZIPOutputStream
+
+def archive = new File('#path#')
+new GZIPOutputStream(new FileOutputStream(archive)).withCloseable { gzos ->
+    gzos.write('inside'.getBytes('UTF-8'))
+}
+setResult(archive.exists())

--- a/tests/cypress/fixtures/getVfsNode.graphql
+++ b/tests/cypress/fixtures/getVfsNode.graphql
@@ -1,0 +1,8 @@
+query getVfsNode($path: String!) {
+    jcr {
+        nodeByPath(path: $path) {
+            name
+            path
+        }
+    }
+}

--- a/tests/cypress/fixtures/modifyVfsJahiaPath.graphql
+++ b/tests/cypress/fixtures/modifyVfsJahiaPath.graphql
@@ -1,0 +1,9 @@
+mutation modifyVfsJahiaPath($pathOrId: String!, $rootPath: String) {
+    admin {
+        jahia {
+            mountPoint {
+                modifyVfs(pathOrId: $pathOrId, rootPath: $rootPath)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/mountVfsJahiaPath.graphql
+++ b/tests/cypress/fixtures/mountVfsJahiaPath.graphql
@@ -1,0 +1,9 @@
+mutation mountVfsJahiaPath($pathOrId: String!) {
+    admin {
+        jahia {
+            mountPoint {
+                mount(pathOrId: $pathOrId)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/setVfsAllowedSchemes.graphql
+++ b/tests/cypress/fixtures/setVfsAllowedSchemes.graphql
@@ -1,0 +1,9 @@
+mutation setVfsAllowedSchemes($value: String!) {
+    admin {
+        jahia {
+            configuration(pid: "org.jahia.modules.external.vfs") {
+                value(name: "vfsMountPoint.allowedSchemes", value: $value)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/setVfsRootPath.groovy
+++ b/tests/cypress/fixtures/setVfsRootPath.groovy
@@ -1,0 +1,10 @@
+// Sets the root of a mount point straight through a system session, so a root the mount point API refuses can still
+// sit on the node — the state an instance is in when the node was stored by an earlier version.
+import org.jahia.services.content.JCRTemplate
+
+setResult(JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
+    def node = session.getNodeByIdentifier('#uuid#')
+    node.setProperty('j:rootPath', '#rootPath#')
+    session.save()
+    return true
+}))

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -100,15 +100,15 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         }
     }
 
-    protected FileObject getRoot() {
+    protected synchronized FileObject getRoot() {
         return root;
     }
 
-    protected String getRootPath() {
+    protected synchronized String getRootPath() {
         return rootPath;
     }
 
-    protected FileSystemManager getManager() {
+    protected synchronized FileSystemManager getManager() {
         return manager;
     }
 

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -52,9 +52,10 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private String rootUnavailableReason;
 
     /**
-     * Defines the root point of the DataSource
+     * Defines the root point of the DataSource. A root that cannot be used leaves the DataSource without one, and
+     * every lookup on it then reports that root as unusable rather than the DataSource reporting it here.
      *
-     * @param rootUri
+     * @param rootUri the root to use
      */
     public void setRoot(String rootUri) {
         rootUnavailableReason = null;
@@ -63,13 +64,15 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             manager = root.getFileSystem().getFileSystemManager();
             rootPath = root.getName().getPath();
         } catch (Exception e) {
-            // The mount point is still mounted, and reports itself unavailable through the accessors below. That is
-            // the state the repository puts on hold and retries, and it leaves the other mount points alone; throwing
-            // here would travel out of ProviderFactory.mountProvider, which the repository calls for each of them.
+            // Every lookup then reports the root as unusable, which is what the repository reads as "this mount point
+            // is not available": it records the reason, puts the mount point on hold and retries it, and leaves the
+            // other mount points alone. Reporting it here instead would travel out of the call the repository makes
+            // for each of them in turn.
             root = null;
             rootPath = null;
-            rootUnavailableReason = "Cannot set root to " + rootUri;
-            logger.warn("{}: {}", rootUnavailableReason, e.getMessage());
+            manager = null;
+            rootUnavailableReason = "Cannot set root to " + rootUri + ": " + e.getMessage();
+            logger.warn(rootUnavailableReason);
         }
     }
 

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -49,6 +49,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private FileObject root;
     private String rootPath;
     private FileSystemManager manager;
+    private String rootUnavailableReason;
 
     /**
      * Defines the root point of the DataSource
@@ -56,12 +57,19 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      * @param rootUri
      */
     public void setRoot(String rootUri) {
+        rootUnavailableReason = null;
         try {
             root = VfsRootResolver.resolveRoot(rootUri);
             manager = root.getFileSystem().getFileSystemManager();
             rootPath = root.getName().getPath();
         } catch (Exception e) {
-            throw new RuntimeException("Cannot set root to " + rootUri, e);
+            // The mount point is still mounted, and reports itself unavailable through the accessors below. That is
+            // the state the repository puts on hold and retries, and it leaves the other mount points alone; throwing
+            // here would travel out of ProviderFactory.mountProvider, which the repository calls for each of them.
+            root = null;
+            rootPath = null;
+            rootUnavailableReason = "Cannot set root to " + rootUri;
+            logger.warn("{}: {}", rootUnavailableReason, e.getMessage());
         }
     }
 
@@ -360,6 +368,10 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     }
 
     private FileObject getFile(String path, boolean unescapePath) throws FileSystemException {
+        if (root == null) {
+            throw new VfsRootNotAllowedException(rootUnavailableReason != null ? rootUnavailableReason
+                    : "The root of this mount point is not set");
+        }
         if (unescapePath) {
             path = Escaping.unescapeIllegalJcrChars(path);
         }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -137,7 +137,12 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         return path.substring(rootPath.length());
     }
 
-    /** @return the root this DataSource serves, or {@code null} while it has none */
+    /**
+     * @return the root this DataSource serves, or {@code null} while it has none
+     */
+    // Reads one immutable value out of an atomic reference, which is what publishes it; taking the monitor that
+    // setting the root takes would add no guarantee to that read, only a wait behind a resolve.
+    @SuppressWarnings("java:S2886")
     protected FileObject getRoot() {
         return root.get().file;
     }
@@ -250,10 +255,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
                     }
                 }
             }
-        } catch (VfsRootNotAllowedException e) {
-            logRootUnavailable(path, e);
         } catch (FileSystemException e) {
-            logger.error("Cannot get node children", e);
+            logChildrenFailure(path, e);
         }
 
         return Collections.emptyList();
@@ -293,10 +296,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
                     }
                 }
             }
-        } catch (VfsRootNotAllowedException e) {
-            logRootUnavailable(path, e);
         } catch (FileSystemException e) {
-            logger.error("Cannot get node children", e);
+            logChildrenFailure(path, e);
         }
 
         return Collections.emptyList();
@@ -445,6 +446,15 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      */
     private void logRootUnavailable(String path, VfsRootNotAllowedException e) {
         logger.debug("Cannot reach {} of this mount point: {}", path, e.getMessage());
+    }
+
+    /** Where a lookup for the children of a path failed: the root of the mount point, or the lookup itself. */
+    private void logChildrenFailure(String path, FileSystemException e) {
+        if (e instanceof VfsRootNotAllowedException) {
+            logRootUnavailable(path, (VfsRootNotAllowedException) e);
+        } else {
+            logger.error("Cannot get node children", e);
+        }
     }
 
     private FileObject getFile(String path, boolean unescapePath) throws FileSystemException {

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -52,8 +52,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private String rootUnavailableReason;
 
     /**
-     * Defines the root point of the DataSource. A root that cannot be used leaves the DataSource without one, and
-     * every lookup on it then reports that root as unusable rather than the DataSource reporting it here.
+     * Defines the root point of the DataSource. This method does not throw: a root that cannot be used leaves the
+     * DataSource without one, and every lookup on it then fails instead.
      *
      * @param rootUri the root to use
      */
@@ -64,10 +64,9 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             manager = root.getFileSystem().getFileSystemManager();
             rootPath = root.getName().getPath();
         } catch (Exception e) {
-            // Every lookup then reports the root as unusable, which is what the repository reads as "this mount point
-            // is not available": it records the reason, puts the mount point on hold and retries it, and leaves the
-            // other mount points alone. Reporting it here instead would travel out of the call the repository makes
-            // for each of them in turn.
+            // Every lookup then fails, which is what the repository reads as "this mount point is not available": it
+            // records the reason, puts the mount point on hold and retries it, and leaves the other mount points
+            // alone. Throwing here would travel out of the call the repository makes for each of them in turn.
             root = null;
             rootPath = null;
             manager = null;

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -53,8 +53,10 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      * How long a root that could not be taken is left alone before a lookup tries it again. A root that names a
      * location which is not answering costs a connection attempt to find out, and that attempt is made while holding
      * this instance, so a mount point on hold must not make one per lookup.
+     *
+     * <p>Not final: a test shortens the window rather than waiting one out.
      */
-    private static final long RETRY_DELAY_NANOS = TimeUnit.SECONDS.toNanos(10);
+    long retryDelayNanos = TimeUnit.SECONDS.toNanos(10);
     /**
      * The root this DataSource serves, and everything derived from it, published as one value: a reader that sees the
      * root sees the path it starts at and the manager that resolved it. Read without a lock on every lookup.
@@ -64,7 +66,12 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     /** The root this DataSource was given, kept so that it can be taken again. Guarded by this. */
     private String rootUri;
 
-    /** When the root was last taken, which is what the retry window is measured from. Guarded by this. */
+    /**
+     * When the last attempt at taking the root ended, which is what the retry window is measured from. Measured from
+     * the end and not the start: a location that is not answering takes longer to say so than the window itself, so a
+     * window measured from the start of the attempt would already have passed by the time the attempt failed, and the
+     * lookup waiting behind it would make another. Guarded by this.
+     */
     private long lastAttempt;
 
     /**
@@ -77,7 +84,6 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         this.rootUri = rootUri;
         // Read before resolving, so a set that changes while this resolves still reads as a change afterwards.
         Set<String> schemes = VfsRootResolver.getAllowedSchemes();
-        lastAttempt = System.nanoTime();
         try {
             root.set(Root.available(VfsRootResolver.resolveRoot(rootUri), schemes));
         } catch (Exception e) {
@@ -91,6 +97,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             } else {
                 logger.warn(reason);
             }
+        } finally {
+            lastAttempt = System.nanoTime();
         }
     }
 
@@ -111,7 +119,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         Root current = root.get();
         Set<String> allowed = VfsRootResolver.getAllowedSchemes();
         if (rootUri != null && !current.isTakenUnder(allowed)
-                && (!current.wasTakenUnder(allowed) || System.nanoTime() - lastAttempt >= RETRY_DELAY_NANOS)) {
+                && (!current.wasTakenUnder(allowed) || System.nanoTime() - lastAttempt >= retryDelayNanos)) {
             setRoot(rootUri);
             current = root.get();
         }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -49,6 +49,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private FileObject root;
     private String rootPath;
     private FileSystemManager manager;
+    private String rootUri;
     private String rootUnavailableReason;
 
     /**
@@ -57,7 +58,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      *
      * @param rootUri the root to use
      */
-    public void setRoot(String rootUri) {
+    public synchronized void setRoot(String rootUri) {
+        this.rootUri = rootUri;
         rootUnavailableReason = null;
         try {
             root = VfsRootResolver.resolveRoot(rootUri);
@@ -65,13 +67,36 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             rootPath = root.getName().getPath();
         } catch (Exception e) {
             // Every lookup then fails, which is what the repository reads as "this mount point is not available": it
-            // records the reason, puts the mount point on hold and retries it, and leaves the other mount points
+            // records the reason, puts the mount point on hold and asks again later, and leaves the other mount points
             // alone. Throwing here would travel out of the call the repository makes for each of them in turn.
             root = null;
             rootPath = null;
             manager = null;
             rootUnavailableReason = "Cannot set root to " + rootUri + ": " + e.getMessage();
             logger.warn(rootUnavailableReason);
+        }
+    }
+
+    /**
+     * The root of this DataSource, taking the root it was given again when it has none. The repository asks a mount
+     * point it put on hold whether it has become available, on the same instance, so a root that could not be used
+     * when the mount point was mounted — a set of schemes not yet configured, a location not yet answering — is
+     * usable from then on without the instance being restarted.
+     */
+    private FileObject requireRoot() throws FileSystemException {
+        FileObject current = root;
+        if (current != null) {
+            return current;
+        }
+        synchronized (this) {
+            if (root == null && rootUri != null) {
+                setRoot(rootUri);
+            }
+            if (root == null) {
+                throw new VfsRootNotAllowedException(rootUnavailableReason != null ? rootUnavailableReason
+                        : "The root of this mount point is not set");
+            }
+            return root;
         }
     }
 
@@ -370,14 +395,11 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     }
 
     private FileObject getFile(String path, boolean unescapePath) throws FileSystemException {
-        if (root == null) {
-            throw new VfsRootNotAllowedException(rootUnavailableReason != null ? rootUnavailableReason
-                    : "The root of this mount point is not set");
-        }
+        FileObject current = requireRoot();
         if (unescapePath) {
             path = Escaping.unescapeIllegalJcrChars(path);
         }
-        return (path == null || path.isEmpty() || path.equals("/")) ? root : root
+        return (path == null || path.isEmpty() || path.equals("/")) ? current : current
                 .resolveFile(path.charAt(0) == '/' ? path.substring(1) : path);
     }
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -57,8 +57,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      */
     public void setRoot(String rootUri) {
         try {
-            manager = VFS.getManager();
-            root = manager.resolveFile(rootUri);
+            root = VfsRootResolver.resolveRoot(rootUri);
+            manager = root.getFileSystem().getFileSystemManager();
             rootPath = root.getName().getPath();
         } catch (Exception e) {
             throw new RuntimeException("Cannot set root to " + rootUri, e);

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -47,6 +48,13 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private static final Set<String> SUPPORTED_NODE_TYPES = new HashSet<String>(Arrays.asList(Constants.JAHIANT_FILE, Constants.JAHIANT_FOLDER, Constants.JAHIANT_RESOURCE));
     private static final Logger logger = LoggerFactory.getLogger(VFSDataSource.class);
     private static final String JCR_CONTENT_SUFFIX = "/" + Constants.JCR_CONTENT;
+
+    /**
+     * How long a root that could not be taken is left alone before a lookup tries it again. A root that names a
+     * location which is not answering costs a connection attempt to find out, and that attempt is made while holding
+     * this instance, so a mount point on hold must not make one per lookup.
+     */
+    private static final long RETRY_DELAY_NANOS = TimeUnit.SECONDS.toNanos(10);
     /**
      * The root this DataSource serves, and everything derived from it, published as one value: a reader that sees the
      * root sees the path it starts at and the manager that resolved it. Read without a lock on every lookup.
@@ -55,6 +63,9 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
     /** The root this DataSource was given, kept so that it can be taken again. Guarded by this. */
     private String rootUri;
+
+    /** When the root was last taken, which is what the retry window is measured from. Guarded by this. */
+    private long lastAttempt;
 
     /**
      * Defines the root point of the DataSource. This method does not throw: a root that cannot be used leaves the
@@ -66,6 +77,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         this.rootUri = rootUri;
         // Read before resolving, so a set that changes while this resolves still reads as a change afterwards.
         Set<String> schemes = VfsRootResolver.getAllowedSchemes();
+        lastAttempt = System.nanoTime();
         try {
             root.set(Root.available(VfsRootResolver.resolveRoot(rootUri), schemes));
         } catch (Exception e) {
@@ -73,8 +85,12 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             // records the reason, puts the mount point on hold and asks again later, and leaves the other mount points
             // alone. Throwing here would travel out of the call the repository makes for each of them in turn.
             String reason = "Cannot set root to " + rootUri + ": " + e.getMessage();
-            root.set(Root.unavailable(reason, schemes));
-            logger.warn(reason);
+            boolean reported = root.getAndSet(Root.unavailable(reason, schemes)).reports(reason);
+            if (reported) {
+                logger.debug(reason);
+            } else {
+                logger.warn(reason);
+            }
         }
     }
 
@@ -93,7 +109,9 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
     private synchronized Root takeRootAgain() throws FileSystemException {
         Root current = root.get();
-        if (rootUri != null && !current.isTakenUnder(VfsRootResolver.getAllowedSchemes())) {
+        Set<String> allowed = VfsRootResolver.getAllowedSchemes();
+        if (rootUri != null && !current.isTakenUnder(allowed)
+                && (!current.wasTakenUnder(allowed) || System.nanoTime() - lastAttempt >= RETRY_DELAY_NANOS)) {
             setRoot(rootUri);
             current = root.get();
         }
@@ -104,20 +122,33 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         return current;
     }
 
-    /** The path of an item of this DataSource, which is the part of its root's path the root does not cover. */
+    /**
+     * The path of an item of this DataSource, which is the part of its name the root's own path does not cover. A name
+     * the root does not cover belongs to a root this DataSource no longer serves, and is answered as a lookup that
+     * fails rather than as a string that is too short.
+     */
     private String pathWithin(FileName name) throws FileSystemException {
-        return name.getPath().substring(requireRoot().path.length());
+        String rootPath = requireRoot().path;
+        String path = name.getPath();
+        if (!path.startsWith(rootPath)) {
+            throw new VfsRootNotAllowedException(String.format("\"%s\" is not under the root \"%s\" of this mount"
+                    + " point", path, rootPath));
+        }
+        return path.substring(rootPath.length());
     }
 
-    protected synchronized FileObject getRoot() {
+    /** @return the root this DataSource serves, or {@code null} while it has none */
+    protected FileObject getRoot() {
         return root.get().file;
     }
 
-    protected synchronized String getRootPath() {
+    /** @return the path the root of this DataSource starts at, or {@code null} while it has no root */
+    protected String getRootPath() {
         return root.get().path;
     }
 
-    protected synchronized FileSystemManager getManager() {
+    /** @return the manager that resolved the root of this DataSource, or {@code null} while it has no root */
+    protected FileSystemManager getManager() {
         return root.get().manager;
     }
 
@@ -136,6 +167,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
             FileObject file = getFile(path.endsWith(JCR_CONTENT_SUFFIX) ? StringUtils.substringBeforeLast(
                     path, JCR_CONTENT_SUFFIX) : path);
             return file.exists();
+        } catch (VfsRootNotAllowedException e) {
+            logRootUnavailable(path, e);
         } catch (FileSystemException e) {
             logger.warn("Unable to check file existence for path " + path, e);
         }
@@ -217,6 +250,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
                     }
                 }
             }
+        } catch (VfsRootNotAllowedException e) {
+            logRootUnavailable(path, e);
         } catch (FileSystemException e) {
             logger.error("Cannot get node children", e);
         }
@@ -258,6 +293,8 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
                     }
                 }
             }
+        } catch (VfsRootNotAllowedException e) {
+            logRootUnavailable(path, e);
         } catch (FileSystemException e) {
             logger.error("Cannot get node children", e);
         }
@@ -402,6 +439,14 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
         return s1;
     }
 
+    /**
+     * A lookup on a mount point that has no root. The root reports itself when it cannot be taken, so a lookup that
+     * finds none says so where a reader looks for it rather than a second time in the log.
+     */
+    private void logRootUnavailable(String path, VfsRootNotAllowedException e) {
+        logger.debug("Cannot reach {} of this mount point: {}", path, e.getMessage());
+    }
+
     private FileObject getFile(String path, boolean unescapePath) throws FileSystemException {
         FileObject current = requireRoot().file;
         if (unescapePath) {
@@ -446,7 +491,17 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
         /** Whether this root is usable and the schemes it was taken under are still the ones a root may name. */
         private boolean isTakenUnder(Set<String> schemes) {
-            return file != null && this.schemes.equals(schemes);
+            return file != null && wasTakenUnder(schemes);
+        }
+
+        /** Whether the schemes this root was taken under are still the ones a root may name, usable or not. */
+        private boolean wasTakenUnder(Set<String> schemes) {
+            return this.schemes.equals(schemes);
+        }
+
+        /** Whether this root already answered for the given failure, so that it is reported once and not per lookup. */
+        private boolean reports(String reason) {
+            return file == null && reason.equals(unavailableReason);
         }
     }
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSDataSource.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * VFS Implementation of ExternalDataSource
@@ -46,11 +47,14 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     private static final Set<String> SUPPORTED_NODE_TYPES = new HashSet<String>(Arrays.asList(Constants.JAHIANT_FILE, Constants.JAHIANT_FOLDER, Constants.JAHIANT_RESOURCE));
     private static final Logger logger = LoggerFactory.getLogger(VFSDataSource.class);
     private static final String JCR_CONTENT_SUFFIX = "/" + Constants.JCR_CONTENT;
-    private FileObject root;
-    private String rootPath;
-    private FileSystemManager manager;
+    /**
+     * The root this DataSource serves, and everything derived from it, published as one value: a reader that sees the
+     * root sees the path it starts at and the manager that resolved it. Read without a lock on every lookup.
+     */
+    private final AtomicReference<Root> root = new AtomicReference<>(Root.unset());
+
+    /** The root this DataSource was given, kept so that it can be taken again. Guarded by this. */
     private String rootUri;
-    private String rootUnavailableReason;
 
     /**
      * Defines the root point of the DataSource. This method does not throw: a root that cannot be used leaves the
@@ -60,56 +64,61 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
      */
     public synchronized void setRoot(String rootUri) {
         this.rootUri = rootUri;
-        rootUnavailableReason = null;
+        // Read before resolving, so a set that changes while this resolves still reads as a change afterwards.
+        Set<String> schemes = VfsRootResolver.getAllowedSchemes();
         try {
-            root = VfsRootResolver.resolveRoot(rootUri);
-            manager = root.getFileSystem().getFileSystemManager();
-            rootPath = root.getName().getPath();
+            root.set(Root.available(VfsRootResolver.resolveRoot(rootUri), schemes));
         } catch (Exception e) {
             // Every lookup then fails, which is what the repository reads as "this mount point is not available": it
             // records the reason, puts the mount point on hold and asks again later, and leaves the other mount points
             // alone. Throwing here would travel out of the call the repository makes for each of them in turn.
-            root = null;
-            rootPath = null;
-            manager = null;
-            rootUnavailableReason = "Cannot set root to " + rootUri + ": " + e.getMessage();
-            logger.warn(rootUnavailableReason);
+            String reason = "Cannot set root to " + rootUri + ": " + e.getMessage();
+            root.set(Root.unavailable(reason, schemes));
+            logger.warn(reason);
         }
     }
 
     /**
-     * The root of this DataSource, taking the root it was given again when it has none. The repository asks a mount
-     * point it put on hold whether it has become available, on the same instance, so a root that could not be used
-     * when the mount point was mounted — a set of schemes not yet configured, a location not yet answering — is
-     * usable from then on without the instance being restarted.
+     * The root of this DataSource, taken again when it has none or when the schemes a root may name have changed since
+     * it was taken. The repository asks a mount point it put on hold whether it has become available, on the same
+     * instance, so a root that could not be used when the mount point was mounted — a set of schemes not yet
+     * configured, a location not yet answering — is usable from then on without the instance being restarted. A set
+     * that stops naming the scheme of a root already resolved stops that root the same way, rather than serving it
+     * until the instance is restarted.
      */
-    private FileObject requireRoot() throws FileSystemException {
-        FileObject current = root;
-        if (current != null) {
-            return current;
+    private Root requireRoot() throws FileSystemException {
+        Root current = root.get();
+        return current.isTakenUnder(VfsRootResolver.getAllowedSchemes()) ? current : takeRootAgain();
+    }
+
+    private synchronized Root takeRootAgain() throws FileSystemException {
+        Root current = root.get();
+        if (rootUri != null && !current.isTakenUnder(VfsRootResolver.getAllowedSchemes())) {
+            setRoot(rootUri);
+            current = root.get();
         }
-        synchronized (this) {
-            if (root == null && rootUri != null) {
-                setRoot(rootUri);
-            }
-            if (root == null) {
-                throw new VfsRootNotAllowedException(rootUnavailableReason != null ? rootUnavailableReason
-                        : "The root of this mount point is not set");
-            }
-            return root;
+        if (current.file == null) {
+            throw new VfsRootNotAllowedException(current.unavailableReason != null ? current.unavailableReason
+                    : "The root of this mount point is not set");
         }
+        return current;
+    }
+
+    /** The path of an item of this DataSource, which is the part of its root's path the root does not cover. */
+    private String pathWithin(FileName name) throws FileSystemException {
+        return name.getPath().substring(requireRoot().path.length());
     }
 
     protected synchronized FileObject getRoot() {
-        return root;
+        return root.get().file;
     }
 
     protected synchronized String getRootPath() {
-        return rootPath;
+        return root.get().path;
     }
 
     protected synchronized FileSystemManager getManager() {
-        return manager;
+        return root.get().manager;
     }
 
     public boolean isSupportsUuid() {
@@ -351,8 +360,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
         }
 
-        String path = fileObject.getName().getPath().substring(rootPath.length());
-        path = Escaping.escapeIllegalJcrChars(path);
+        String path = Escaping.escapeIllegalJcrChars(pathWithin(fileObject.getName()));
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
@@ -372,7 +380,7 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
 
         properties.put(Constants.JCR_MIMETYPE, new String[]{getContentType(content)});
 
-        String path = Escaping.escapeIllegalJcrChars(content.getFile().getName().getPath().substring(rootPath.length()));
+        String path = Escaping.escapeIllegalJcrChars(pathWithin(content.getFile().getName()));
         String jcrContentPath = path + "/" + Constants.JCR_CONTENT;
         ExternalData externalData = new ExternalData(jcrContentPath, jcrContentPath, Constants.JAHIANT_RESOURCE, properties);
 
@@ -395,11 +403,50 @@ public class VFSDataSource implements ExternalDataSource, ExternalDataSource.Wri
     }
 
     private FileObject getFile(String path, boolean unescapePath) throws FileSystemException {
-        FileObject current = requireRoot();
+        FileObject current = requireRoot().file;
         if (unescapePath) {
             path = Escaping.unescapeIllegalJcrChars(path);
         }
         return (path == null || path.isEmpty() || path.equals("/")) ? current : current
                 .resolveFile(path.charAt(0) == '/' ? path.substring(1) : path);
+    }
+
+    /**
+     * A root and what is derived from it: the path it starts at, the manager that resolved it, and the schemes it was
+     * taken under. Immutable, so the whole group is published at once and a reader needs no lock to see all of it.
+     */
+    private static final class Root {
+
+        private final FileObject file;
+        private final String path;
+        private final FileSystemManager manager;
+        private final String unavailableReason;
+        private final Set<String> schemes;
+
+        private Root(FileObject file, String path, FileSystemManager manager, String unavailableReason,
+                Set<String> schemes) {
+            this.file = file;
+            this.path = path;
+            this.manager = manager;
+            this.unavailableReason = unavailableReason;
+            this.schemes = schemes;
+        }
+
+        private static Root available(FileObject file, Set<String> schemes) {
+            return new Root(file, file.getName().getPath(), file.getFileSystem().getFileSystemManager(), null, schemes);
+        }
+
+        private static Root unavailable(String reason, Set<String> schemes) {
+            return new Root(null, null, null, reason, schemes);
+        }
+
+        private static Root unset() {
+            return unavailable(null, Collections.emptySet());
+        }
+
+        /** Whether this root is usable and the schemes it was taken under are still the ones a root may name. */
+        private boolean isTakenUnder(Set<String> schemes) {
+            return file != null && this.schemes.equals(schemes);
+        }
     }
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
@@ -70,9 +70,9 @@ public class VFSProviderFactory implements ProviderFactory {
             provider.start();
             return provider;
         } catch (JahiaInitializationException | RuntimeException e) {
-            // RuntimeException is in there because the repository calls this for each mount point in turn and handles
-            // a RepositoryException, while an unchecked one would travel further and leave the mount points after
-            // this one unmounted. The repository logs what it catches, so the cause travels with it.
+            // RuntimeException is in there because this is called from a declarative-services bind method, which an
+            // unchecked exception fails outright; a RepositoryException is what the repository declares and logs. It
+            // logs the cause with it, so it is not logged again here.
             throw new RepositoryException(e);
         }
     }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
@@ -22,6 +22,8 @@ import org.jahia.services.content.*;
 import org.jahia.modules.external.ExternalContentStoreProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 
@@ -30,6 +32,8 @@ import javax.jcr.RepositoryException;
  */
 @Component(service = ProviderFactory.class, immediate = true)
 public class VFSProviderFactory implements ProviderFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(VFSProviderFactory.class);
 
     @Reference
     private ExternalContentStoreProviderFactory externalContentStoreProviderFactory;
@@ -57,22 +61,26 @@ public class VFSProviderFactory implements ProviderFactory {
      */
     @Override
     public JCRStoreProvider mountProvider(JCRNodeWrapper mountPoint) throws RepositoryException {
-        ExternalContentStoreProvider provider = externalContentStoreProviderFactory.newProvider();
-        provider.setKey(mountPoint.getIdentifier());
-        provider.setMountPoint(mountPoint.getPath());
-
-        VFSDataSource dataSource = new VFSDataSource();
-        dataSource.setRoot(mountPoint.getProperty("j:rootPath").getString());
-        provider.setDataSource(dataSource);
-        provider.setDynamicallyMounted(true);
-        provider.setSessionFactory(JCRSessionFactory.getInstance());
         try {
+            ExternalContentStoreProvider provider = externalContentStoreProviderFactory.newProvider();
+            provider.setKey(mountPoint.getIdentifier());
+            provider.setMountPoint(mountPoint.getPath());
+
+            VFSDataSource dataSource = new VFSDataSource();
+            dataSource.setRoot(mountPoint.getProperty("j:rootPath").getString());
+            provider.setDataSource(dataSource);
+            provider.setDynamicallyMounted(true);
+            provider.setSessionFactory(JCRSessionFactory.getInstance());
             provider.start();
+            return provider;
         } catch (JahiaInitializationException e) {
             throw new RepositoryException(e);
+        } catch (RuntimeException e) {
+            // The repository calls this for each mount point in turn and handles a RepositoryException; an unchecked
+            // one would travel further and leave the mount points after this one unmounted.
+            logger.error("Cannot mount the VFS provider declared at {}", mountPoint.getPath(), e);
+            throw new RepositoryException(e);
         }
-        return provider;
-
     }
 
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
@@ -69,12 +69,10 @@ public class VFSProviderFactory implements ProviderFactory {
             provider.setSessionFactory(JCRSessionFactory.getInstance());
             provider.start();
             return provider;
-        } catch (JahiaInitializationException e) {
-            throw new RepositoryException(e);
-        } catch (RuntimeException e) {
-            // The repository calls this for each mount point in turn and handles a RepositoryException; an unchecked
-            // one would travel further and leave the mount points after this one unmounted. It logs what it catches,
-            // so the cause travels with it rather than being logged again here.
+        } catch (JahiaInitializationException | RuntimeException e) {
+            // RuntimeException is in there because the repository calls this for each mount point in turn and handles
+            // a RepositoryException, while an unchecked one would travel further and leave the mount points after
+            // this one unmounted. The repository logs what it catches, so the cause travels with it.
             throw new RepositoryException(e);
         }
     }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
@@ -70,9 +70,9 @@ public class VFSProviderFactory implements ProviderFactory {
             provider.start();
             return provider;
         } catch (JahiaInitializationException | RuntimeException e) {
-            // RuntimeException is in there because this is called from a declarative-services bind method, which an
-            // unchecked exception fails outright; a RepositoryException is what the repository declares and logs. It
-            // logs the cause with it, so it is not logged again here.
+            // RuntimeException is in there because one of the callers of this method is a declarative-services bind
+            // method, which an unchecked exception fails outright; a RepositoryException is what the repository
+            // declares and logs. It logs the cause with it, so it is not logged again here.
             throw new RepositoryException(e);
         }
     }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VFSProviderFactory.java
@@ -22,8 +22,6 @@ import org.jahia.services.content.*;
 import org.jahia.modules.external.ExternalContentStoreProvider;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 
@@ -32,8 +30,6 @@ import javax.jcr.RepositoryException;
  */
 @Component(service = ProviderFactory.class, immediate = true)
 public class VFSProviderFactory implements ProviderFactory {
-
-    private static final Logger logger = LoggerFactory.getLogger(VFSProviderFactory.class);
 
     @Reference
     private ExternalContentStoreProviderFactory externalContentStoreProviderFactory;
@@ -77,8 +73,8 @@ public class VFSProviderFactory implements ProviderFactory {
             throw new RepositoryException(e);
         } catch (RuntimeException e) {
             // The repository calls this for each mount point in turn and handles a RepositoryException; an unchecked
-            // one would travel further and leave the mount points after this one unmounted.
-            logger.error("Cannot mount the VFS provider declared at {}", mountPoint.getPath(), e);
+            // one would travel further and leave the mount points after this one unmounted. It logs what it catches,
+            // so the cause travels with it rather than being logged again here.
             throw new RepositoryException(e);
         }
     }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
@@ -1,0 +1,42 @@
+package org.jahia.modules.external.vfs;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Reads the schemes a VFS mount point root may use from the {@value #PID} configuration and hands them to
+ * {@link VfsRootResolver}. Without a configuration the resolver keeps its own default, the local filesystem alone.
+ */
+@Component(service = {}, immediate = true, configurationPid = VfsRootConfiguration.PID)
+public class VfsRootConfiguration {
+
+    static final String PID = "org.jahia.modules.external.vfs";
+
+    /** Comma-separated list of URI schemes a mount point root may use. */
+    static final String ALLOWED_SCHEMES = "vfsMountPoint.allowedSchemes";
+
+    @Activate
+    public void activate(Map<String, ?> properties) {
+        apply(properties);
+    }
+
+    @Modified
+    public void modified(Map<String, ?> properties) {
+        apply(properties);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        VfsRootResolver.setAllowedSchemes(null);
+    }
+
+    private static void apply(Map<String, ?> properties) {
+        Object schemes = properties != null ? properties.get(ALLOWED_SCHEMES) : null;
+        VfsRootResolver.setAllowedSchemes(schemes != null ? Arrays.asList(schemes.toString().split(",")) : null);
+    }
+}

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
@@ -4,30 +4,47 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Reads the schemes a VFS mount point root may use from the {@value #PID} configuration and hands them to
- * {@link VfsRootResolver}. Without a configuration the resolver keeps its own default, the local filesystem alone.
+ * {@link VfsRootResolver}.
  */
 @Component(service = {}, immediate = true, configurationPid = VfsRootConfiguration.PID)
+@Designate(ocd = VfsRootConfiguration.Config.class)
 public class VfsRootConfiguration {
 
     static final String PID = "org.jahia.modules.external.vfs";
 
-    /** Comma-separated list of URI schemes a mount point root may use. */
     static final String ALLOWED_SCHEMES = "vfsMountPoint.allowedSchemes";
 
+    @ObjectClassDefinition(name = "Jahia VFS mount points", description = "Settings for VFS mount points")
+    public @interface Config {
+
+        @AttributeDefinition(name = "Allowed root schemes",
+                description = "URI schemes the root path of a VFS mount point may use. The local file system is the"
+                        + " default; name a further scheme here when a mount point needs it.")
+        String[] vfsMountPoint_allowedSchemes() default {VfsRootResolver.LOCAL_SCHEME};
+    }
+
     @Activate
-    public void activate(Map<String, ?> properties) {
-        apply(properties);
+    public void activate(Config config, Map<String, Object> properties) {
+        apply(config, properties);
     }
 
     @Modified
-    public void modified(Map<String, ?> properties) {
-        apply(properties);
+    public void modified(Config config, Map<String, Object> properties) {
+        apply(config, properties);
     }
 
     @Deactivate
@@ -35,8 +52,27 @@ public class VfsRootConfiguration {
         VfsRootResolver.setAllowedSchemes(null);
     }
 
-    private static void apply(Map<String, ?> properties) {
-        Object schemes = properties != null ? properties.get(ALLOWED_SCHEMES) : null;
-        VfsRootResolver.setAllowedSchemes(schemes != null ? Arrays.asList(schemes.toString().split(",")) : null);
+    private static void apply(Config config, Map<String, Object> properties) {
+        Object value = properties != null ? properties.get(ALLOWED_SCHEMES) : null;
+        VfsRootResolver.setAllowedSchemes(
+                value != null ? schemesOf(value) : Arrays.asList(config.vfsMountPoint_allowedSchemes()));
+    }
+
+    /**
+     * Reads the configured schemes off the raw value rather than the typed accessor, because a {@code .cfg} file
+     * carries them as one comma-separated string while Config Admin carries them as a collection.
+     */
+    private static List<String> schemesOf(Object value) {
+        Stream<?> values;
+        if (value instanceof Object[]) {
+            values = Arrays.stream((Object[]) value);
+        } else if (value instanceof Collection) {
+            values = ((Collection<?>) value).stream();
+        } else {
+            values = Stream.of(value);
+        }
+        return values.filter(Objects::nonNull)
+                .flatMap(scheme -> Arrays.stream(scheme.toString().split(",")))
+                .collect(Collectors.toList());
     }
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
@@ -1,68 +1,54 @@
 package org.jahia.modules.external.vfs;
 
-import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.metatype.annotations.AttributeDefinition;
-import org.osgi.service.metatype.annotations.Designate;
-import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Dictionary;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Reads the schemes a VFS mount point root may use from the {@value #PID} configuration and hands them to
- * {@link VfsRootResolver}.
+ * OSGI configuration for VFS mount points
  */
-@Component(service = {}, immediate = true, configurationPid = VfsRootConfiguration.PID)
-@Designate(ocd = VfsRootConfiguration.Config.class)
-public class VfsRootConfiguration {
+@Component(service = ManagedService.class, immediate = true, property = {
+        "service.pid=" + VfsRootConfiguration.PID,
+        "service.description=VFS mount point configuration service",
+        "service.vendor=Jahia Solutions Group SA"
+})
+public class VfsRootConfiguration implements ManagedService {
 
     static final String PID = "org.jahia.modules.external.vfs";
 
-    static final String ALLOWED_SCHEMES = "vfsMountPoint.allowedSchemes";
+    // Configuration keys
+    static final String KEY_ALLOWED_SCHEMES = "vfsMountPoint.allowedSchemes";
 
-    @ObjectClassDefinition(name = "Jahia VFS mount points", description = "Settings for VFS mount points")
-    public @interface Config {
+    private static final Logger logger = LoggerFactory.getLogger(VfsRootConfiguration.class);
 
-        @AttributeDefinition(name = "Allowed root schemes",
-                description = "URI schemes the root path of a VFS mount point may use. The local file system is the"
-                        + " default; name a further scheme here when a mount point needs it.")
-        String[] vfsMountPoint_allowedSchemes() default {VfsRootResolver.LOCAL_SCHEME};
-    }
-
-    @Activate
-    public void activate(Config config, Map<String, Object> properties) {
-        apply(config, properties);
-    }
-
-    @Modified
-    public void modified(Config config, Map<String, Object> properties) {
-        apply(config, properties);
-    }
-
-    @Deactivate
-    public void deactivate() {
-        VfsRootResolver.setAllowedSchemes(null);
-    }
-
-    private static void apply(Config config, Map<String, Object> properties) {
-        Object value = properties != null ? properties.get(ALLOWED_SCHEMES) : null;
-        VfsRootResolver.setAllowedSchemes(
-                value != null ? schemesOf(value) : Arrays.asList(config.vfsMountPoint_allowedSchemes()));
+    @Override
+    public void updated(Dictionary<String, ?> properties) {
+        if (properties == null) {
+            logger.info("No configuration found for VFS mount points, using defaults");
+            VfsRootResolver.setAllowedSchemes(null);
+            return;
+        }
+        VfsRootResolver.setAllowedSchemes(getSchemesProperty(properties, KEY_ALLOWED_SCHEMES));
     }
 
     /**
-     * Reads the configured schemes off the raw value rather than the typed accessor, because a {@code .cfg} file
-     * carries them as one comma-separated string while Config Admin carries them as a collection.
+     * Reads a scheme list, which a {@code .cfg} file carries as one comma-separated string and Config Admin carries
+     * as a collection.
      */
-    private static List<String> schemesOf(Object value) {
+    private static List<String> getSchemesProperty(Dictionary<String, ?> properties, String key) {
+        Object value = properties.get(key);
+        if (value == null) {
+            return null;
+        }
         Stream<?> values;
         if (value instanceof Object[]) {
             values = Arrays.stream((Object[]) value);

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootConfiguration.java
@@ -2,6 +2,7 @@ package org.jahia.modules.external.vfs;
 
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,11 @@ public class VfsRootConfiguration implements ManagedService {
             return;
         }
         VfsRootResolver.setAllowedSchemes(getSchemesProperty(properties, KEY_ALLOWED_SCHEMES));
+    }
+
+    @Deactivate
+    public void deactivate() {
+        VfsRootResolver.close();
     }
 
     /**

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootNotAllowedException.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootNotAllowedException.java
@@ -1,0 +1,27 @@
+package org.jahia.modules.external.vfs;
+
+import org.apache.commons.vfs2.FileSystemException;
+
+/**
+ * Signals that the root path of a VFS mount point cannot be used.
+ *
+ * <p>A {@link FileSystemException} so that callers already handling one keep working, but the message is the plain
+ * text passed in: the base class reads its message as a key into Apache VFS's own resource bundle, and a text that
+ * is not a key there renders as {@code Unknown message with code "..."}.
+ */
+public class VfsRootNotAllowedException extends FileSystemException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String message;
+
+    public VfsRootNotAllowedException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -12,9 +12,11 @@ import org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -104,23 +106,32 @@ public final class VfsRootResolver {
         if (StringUtils.isBlank(rootPath)) {
             throw new VfsRootNotAllowedException("The root path of a VFS mount point must not be blank");
         }
-        String scheme = schemeOf(rootPath);
         Set<String> allowed = allowedSchemes.get();
-        if (!allowed.contains(scheme)) {
-            throw new VfsRootNotAllowedException(String.format(
-                    "The root \"%s\" uses the URI scheme \"%s\", which is not among the schemes a VFS mount point"
-                            + " root may use: %s",
-                    rootPath, scheme, allowed));
+        for (String scheme : schemesOf(rootPath)) {
+            if (!allowed.contains(scheme)) {
+                throw new VfsRootNotAllowedException(String.format(
+                        "The root \"%s\" uses the URI scheme \"%s\", which is not among the schemes a VFS mount"
+                                + " point root may use: %s",
+                        rootPath, scheme, allowed));
+            }
         }
     }
 
     /**
-     * The scheme a root names, which is the local file system when it names none — a plain path and a {@code file:}
-     * URI reach the same place, so the allowed set answers for both alike.
+     * The schemes a root names, outermost first. A layered scheme names one per layer and reaches whatever the layer
+     * below it names, so {@code gz:http://host/} reaches the network as surely as {@code http://host/} does and the
+     * allowed set has to answer for each of them. A root naming no scheme names the local file system: a plain path
+     * and a {@code file:} URI reach the same place, so the set answers for both alike.
      */
-    private static String schemeOf(String rootPath) {
-        Matcher matcher = SCHEME_PREFIX.matcher(rootPath);
-        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : LOCAL_SCHEME;
+    private static List<String> schemesOf(String rootPath) {
+        List<String> schemes = new ArrayList<>();
+        String remainder = rootPath;
+        for (Matcher matcher = SCHEME_PREFIX.matcher(remainder); matcher.lookingAt();
+                matcher = SCHEME_PREFIX.matcher(remainder)) {
+            schemes.add(matcher.group(1).toLowerCase(Locale.ROOT));
+            remainder = remainder.substring(matcher.end());
+        }
+        return schemes.isEmpty() ? Collections.singletonList(LOCAL_SCHEME) : schemes;
     }
 
     /**

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -9,6 +9,8 @@ import org.apache.commons.vfs2.VFS;
 import org.apache.commons.vfs2.cache.SoftRefFilesCache;
 import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +28,8 @@ import java.util.regex.Pattern;
  */
 public final class VfsRootResolver {
 
+    private static final Logger logger = LoggerFactory.getLogger(VfsRootResolver.class);
+
     /** The scheme of the local filesystem, and the only one allowed unless a configuration widens the set. */
     public static final String LOCAL_SCHEME = "file";
 
@@ -36,6 +40,9 @@ public final class VfsRootResolver {
      * not matched, so a Windows drive ({@code d:/data}) stays a filesystem path rather than reading as a scheme.
      */
     private static final Pattern SCHEME_PREFIX = Pattern.compile("^([a-zA-Z][a-zA-Z0-9+.-]+):");
+
+    /** The shape of a scheme name, applied to a configured value before it joins the allowed set. */
+    private static final Pattern SCHEME_NAME = Pattern.compile("[a-z][a-z0-9+.-]+");
 
     private static volatile Set<String> allowedSchemes = LOCAL_ONLY;
 
@@ -60,23 +67,34 @@ public final class VfsRootResolver {
     /**
      * @return the schemes a mount point root may currently use
      */
-    public static Set<String> getAllowedSchemes() {
+    static Set<String> getAllowedSchemes() {
         return allowedSchemes;
     }
 
     /**
-     * Sets the schemes a mount point root may use. A null or empty collection restores the local filesystem alone.
+     * Sets the schemes a mount point root may use. A null or empty collection, and any value that is not the name of
+     * a scheme, restores the local filesystem alone: a set this cannot read is the one case where widening must not
+     * happen, since the set also decides which providers the resolving manager carries.
      */
     static void setAllowedSchemes(Collection<String> schemes) {
         Set<String> normalized = new LinkedHashSet<>();
         if (schemes != null) {
             for (String scheme : schemes) {
-                if (StringUtils.isNotBlank(scheme)) {
-                    normalized.add(scheme.trim().toLowerCase(Locale.ROOT));
+                String candidate = StringUtils.trimToEmpty(scheme).toLowerCase(Locale.ROOT);
+                if (SCHEME_NAME.matcher(candidate).matches()) {
+                    normalized.add(candidate);
+                } else if (StringUtils.isNotBlank(candidate)) {
+                    logger.warn("Ignoring \"{}\", which is not the name of a URI scheme, in the schemes a VFS mount"
+                            + " point root may use", candidate);
                 }
             }
         }
         allowedSchemes = normalized.isEmpty() ? LOCAL_ONLY : Collections.unmodifiableSet(normalized);
+        if (LOCAL_ONLY.equals(allowedSchemes)) {
+            logger.info("A VFS mount point root may name the local file system");
+        } else {
+            logger.info("A VFS mount point root may name any of {}", allowedSchemes);
+        }
     }
 
     static void checkSchemeAllowed(String rootPath) throws FileSystemException {

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,9 +45,10 @@ public final class VfsRootResolver {
     /** The shape of a scheme name, applied to a configured value before it joins the allowed set. */
     private static final Pattern SCHEME_NAME = Pattern.compile("[a-z][a-z0-9+.-]+");
 
-    private static volatile Set<String> allowedSchemes = LOCAL_ONLY;
+    private static final AtomicReference<Set<String>> allowedSchemes = new AtomicReference<>(LOCAL_ONLY);
 
-    private static volatile FileSystemManager localOnlyManager;
+    /** Only ever touched from the synchronized methods below, so it needs no memory barrier of its own. */
+    private static DefaultFileSystemManager localOnlyManager;
 
     private VfsRootResolver() {
         throw new IllegalStateException("Utility class is not meant to be instantiated");
@@ -61,14 +63,14 @@ public final class VfsRootResolver {
      */
     public static FileObject resolveRoot(String rootPath) throws FileSystemException {
         checkSchemeAllowed(rootPath);
-        return managerFor(allowedSchemes).resolveFile(rootPath);
+        return managerFor(allowedSchemes.get()).resolveFile(rootPath);
     }
 
     /**
      * @return the schemes a mount point root may currently use
      */
     static Set<String> getAllowedSchemes() {
-        return allowedSchemes;
+        return allowedSchemes.get();
     }
 
     /**
@@ -89,11 +91,12 @@ public final class VfsRootResolver {
                 }
             }
         }
-        allowedSchemes = normalized.isEmpty() ? LOCAL_ONLY : Collections.unmodifiableSet(normalized);
-        if (LOCAL_ONLY.equals(allowedSchemes)) {
+        Set<String> applied = normalized.isEmpty() ? LOCAL_ONLY : Collections.unmodifiableSet(normalized);
+        allowedSchemes.set(applied);
+        if (LOCAL_ONLY.equals(applied)) {
             logger.info("A VFS mount point root may name the local file system");
         } else {
-            logger.info("A VFS mount point root may name any of {}", allowedSchemes);
+            logger.info("A VFS mount point root may name any of {}", applied);
         }
     }
 
@@ -102,7 +105,7 @@ public final class VfsRootResolver {
             throw new VfsRootNotAllowedException("The root path of a VFS mount point must not be blank");
         }
         String scheme = schemeOf(rootPath);
-        Set<String> allowed = allowedSchemes;
+        Set<String> allowed = allowedSchemes.get();
         if (scheme != null && !allowed.contains(scheme)) {
             throw new VfsRootNotAllowedException(String.format(
                     "The URI scheme \"%s\" is not among the schemes a VFS mount point root may use: %s",
@@ -126,14 +129,29 @@ public final class VfsRootResolver {
     private static synchronized FileSystemManager localOnlyManager() throws FileSystemException {
         if (localOnlyManager == null) {
             DefaultFileSystemManager manager = new DefaultFileSystemManager();
-            manager.setFilesCache(new SoftRefFilesCache());
-            manager.setCacheStrategy(CacheStrategy.ON_RESOLVE);
-            manager.addProvider(LOCAL_SCHEME, new DefaultLocalFileProvider());
-            // Neither a default provider nor a base file is set, so a root resolves only when the local provider
-            // claims it.
-            manager.init();
+            try {
+                manager.setFilesCache(new SoftRefFilesCache());
+                manager.setCacheStrategy(CacheStrategy.ON_RESOLVE);
+                manager.addProvider(LOCAL_SCHEME, new DefaultLocalFileProvider());
+                // Neither a default provider nor a base file is set, so a root resolves only when the local provider
+                // claims it.
+                manager.init();
+            } catch (FileSystemException e) {
+                manager.close();
+                throw e;
+            }
             localOnlyManager = manager;
         }
         return localOnlyManager;
+    }
+
+    /**
+     * Releases the manager this resolver holds. Called when the bundle stops, so a redeployment starts from a new one.
+     */
+    static synchronized void close() {
+        if (localOnlyManager != null) {
+            localOnlyManager.close();
+            localOnlyManager = null;
+        }
     }
 }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -108,8 +108,9 @@ public final class VfsRootResolver {
         Set<String> allowed = allowedSchemes.get();
         if (!allowed.contains(scheme)) {
             throw new VfsRootNotAllowedException(String.format(
-                    "The URI scheme \"%s\" is not among the schemes a VFS mount point root may use: %s",
-                    scheme, allowed));
+                    "The root \"%s\" uses the URI scheme \"%s\", which is not among the schemes a VFS mount point"
+                            + " root may use: %s",
+                    rootPath, scheme, allowed));
         }
     }
 

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -64,11 +64,16 @@ public final class VfsRootResolver {
      * @throws FileSystemException if the root path is blank, uses a scheme that is not allowed, or cannot be resolved
      */
     public static FileObject resolveRoot(String rootPath) throws FileSystemException {
-        checkSchemeAllowed(rootPath);
-        return managerFor(allowedSchemes.get()).resolveFile(rootPath);
+        // One read answers both questions, so the check and the manager carrying the providers cannot disagree.
+        Set<String> allowed = allowedSchemes.get();
+        checkSchemeAllowed(rootPath, allowed);
+        return managerFor(allowed).resolveFile(rootPath);
     }
 
     /**
+     * The set is replaced rather than modified, so the value returned here is also what a mount point records to know
+     * the configuration its root was taken under.
+     *
      * @return the schemes a mount point root may currently use
      */
     static Set<String> getAllowedSchemes() {
@@ -103,10 +108,13 @@ public final class VfsRootResolver {
     }
 
     static void checkSchemeAllowed(String rootPath) throws FileSystemException {
+        checkSchemeAllowed(rootPath, allowedSchemes.get());
+    }
+
+    private static void checkSchemeAllowed(String rootPath, Set<String> allowed) throws FileSystemException {
         if (StringUtils.isBlank(rootPath)) {
             throw new VfsRootNotAllowedException("The root path of a VFS mount point must not be blank");
         }
-        Set<String> allowed = allowedSchemes.get();
         for (String scheme : schemesOf(rootPath)) {
             if (!allowed.contains(scheme)) {
                 throw new VfsRootNotAllowedException(String.format(
@@ -120,8 +128,10 @@ public final class VfsRootResolver {
     /**
      * The schemes a root names, outermost first. A layered scheme names one per layer and reaches whatever the layer
      * below it names, so {@code gz:http://host/} reaches the network as surely as {@code http://host/} does and the
-     * allowed set has to answer for each of them. A root naming no scheme names the local file system: a plain path
-     * and a {@code file:} URI reach the same place, so the set answers for both alike.
+     * allowed set has to answer for each of them. What the innermost layer names is told by what follows it: an
+     * authority ({@code //host/…}) belongs to the scheme above it, anything else is a path, and a path names the local
+     * file system. So {@code gz:/data/archive.gz} names {@code gz} over {@code file}, the same pair as
+     * {@code gz:file:///data/archive.gz}, and a bare {@code /data} names {@code file} as {@code file:///data} does.
      */
     private static List<String> schemesOf(String rootPath) {
         List<String> schemes = new ArrayList<>();
@@ -131,7 +141,10 @@ public final class VfsRootResolver {
             schemes.add(matcher.group(1).toLowerCase(Locale.ROOT));
             remainder = remainder.substring(matcher.end());
         }
-        return schemes.isEmpty() ? Collections.singletonList(LOCAL_SCHEME) : schemes;
+        if (schemes.isEmpty() || !remainder.startsWith("//")) {
+            schemes.add(LOCAL_SCHEME);
+        }
+        return schemes;
     }
 
     /**

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -74,9 +74,9 @@ public final class VfsRootResolver {
     }
 
     /**
-     * Sets the schemes a mount point root may use. A null or empty collection, and any value that is not the name of
-     * a scheme, restores the local filesystem alone: a set this cannot read is the one case where widening must not
-     * happen, since the set also decides which providers the resolving manager carries.
+     * Sets the schemes a mount point root may use. A value that is not the name of a scheme is reported and dropped,
+     * and a set left with nothing readable in it restores the local filesystem alone: the set also decides which
+     * providers the resolving manager carries, so it must not widen on a value it cannot read.
      */
     static void setAllowedSchemes(Collection<String> schemes) {
         Set<String> normalized = new LinkedHashSet<>();
@@ -106,16 +106,20 @@ public final class VfsRootResolver {
         }
         String scheme = schemeOf(rootPath);
         Set<String> allowed = allowedSchemes.get();
-        if (scheme != null && !allowed.contains(scheme)) {
+        if (!allowed.contains(scheme)) {
             throw new VfsRootNotAllowedException(String.format(
                     "The URI scheme \"%s\" is not among the schemes a VFS mount point root may use: %s",
                     scheme, allowed));
         }
     }
 
+    /**
+     * The scheme a root names, which is the local file system when it names none — a plain path and a {@code file:}
+     * URI reach the same place, so the allowed set answers for both alike.
+     */
     private static String schemeOf(String rootPath) {
         Matcher matcher = SCHEME_PREFIX.matcher(rootPath);
-        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : null;
+        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : LOCAL_SCHEME;
     }
 
     /**

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/VfsRootResolver.java
@@ -1,0 +1,121 @@
+package org.jahia.modules.external.vfs;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.vfs2.CacheStrategy;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.cache.SoftRefFilesCache;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves the root path a VFS mount point points at, restricted to the URI schemes a mount point is allowed to use.
+ *
+ * <p>Every caller that turns a {@code j:rootPath} value into a {@link FileObject} goes through here, so a mount point
+ * is validated and mounted against the same set of schemes.
+ */
+public final class VfsRootResolver {
+
+    /** The scheme of the local filesystem, and the only one allowed unless a configuration widens the set. */
+    public static final String LOCAL_SCHEME = "file";
+
+    private static final Set<String> LOCAL_ONLY = Collections.singleton(LOCAL_SCHEME);
+
+    /**
+     * Matches a root path that opens with a URI scheme naming a VFS provider. A single leading letter is deliberately
+     * not matched, so a Windows drive ({@code d:/data}) stays a filesystem path rather than reading as a scheme.
+     */
+    private static final Pattern SCHEME_PREFIX = Pattern.compile("^([a-zA-Z][a-zA-Z0-9+.-]+):");
+
+    private static volatile Set<String> allowedSchemes = LOCAL_ONLY;
+
+    private static volatile FileSystemManager localOnlyManager;
+
+    private VfsRootResolver() {
+        throw new IllegalStateException("Utility class is not meant to be instantiated");
+    }
+
+    /**
+     * Resolves the root path of a VFS mount point.
+     *
+     * @param rootPath the {@code j:rootPath} value of the mount point
+     * @return the resolved root
+     * @throws FileSystemException if the root path is blank, uses a scheme that is not allowed, or cannot be resolved
+     */
+    public static FileObject resolveRoot(String rootPath) throws FileSystemException {
+        checkSchemeAllowed(rootPath);
+        return managerFor(allowedSchemes).resolveFile(rootPath);
+    }
+
+    /**
+     * @return the schemes a mount point root may currently use
+     */
+    public static Set<String> getAllowedSchemes() {
+        return allowedSchemes;
+    }
+
+    /**
+     * Sets the schemes a mount point root may use. A null or empty collection restores the local filesystem alone.
+     */
+    static void setAllowedSchemes(Collection<String> schemes) {
+        Set<String> normalized = new LinkedHashSet<>();
+        if (schemes != null) {
+            for (String scheme : schemes) {
+                if (StringUtils.isNotBlank(scheme)) {
+                    normalized.add(scheme.trim().toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        allowedSchemes = normalized.isEmpty() ? LOCAL_ONLY : Collections.unmodifiableSet(normalized);
+    }
+
+    static void checkSchemeAllowed(String rootPath) throws FileSystemException {
+        if (StringUtils.isBlank(rootPath)) {
+            throw new VfsRootNotAllowedException("The root path of a VFS mount point must not be blank");
+        }
+        String scheme = schemeOf(rootPath);
+        Set<String> allowed = allowedSchemes;
+        if (scheme != null && !allowed.contains(scheme)) {
+            throw new VfsRootNotAllowedException(String.format(
+                    "The URI scheme \"%s\" is not among the schemes a VFS mount point root may use: %s",
+                    scheme, allowed));
+        }
+    }
+
+    private static String schemeOf(String rootPath) {
+        Matcher matcher = SCHEME_PREFIX.matcher(rootPath);
+        return matcher.find() ? matcher.group(1).toLowerCase(Locale.ROOT) : null;
+    }
+
+    /**
+     * On the local-only default, a manager carrying just the local provider. A configuration naming further schemes
+     * needs the shared manager, which is the one carrying their providers.
+     */
+    private static FileSystemManager managerFor(Set<String> allowed) throws FileSystemException {
+        return LOCAL_ONLY.containsAll(allowed) ? localOnlyManager() : VFS.getManager();
+    }
+
+    private static synchronized FileSystemManager localOnlyManager() throws FileSystemException {
+        if (localOnlyManager == null) {
+            DefaultFileSystemManager manager = new DefaultFileSystemManager();
+            manager.setFilesCache(new SoftRefFilesCache());
+            manager.setCacheStrategy(CacheStrategy.ON_RESOLVE);
+            manager.addProvider(LOCAL_SCHEME, new DefaultLocalFileProvider());
+            // Neither a default provider nor a base file is set, so a root resolves only when the local provider
+            // claims it.
+            manager.init();
+            localOnlyManager = manager;
+        }
+        return localOnlyManager;
+    }
+}

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/factory/VFSMountPointFactoryHandler.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/factory/VFSMountPointFactoryHandler.java
@@ -17,8 +17,8 @@ package org.jahia.modules.external.vfs.factory;
 
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.VFS;
 import org.jahia.modules.external.admin.mount.AbstractMountPointFactoryHandler;
+import org.jahia.modules.external.vfs.VfsRootResolver;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -131,7 +131,7 @@ public class VFSMountPointFactoryHandler extends AbstractMountPointFactoryHandle
      */
     private boolean validateVFS(VFSMountPointFactory vfsMountPointFactory) {
         try {
-            VFS.getManager().resolveFile(vfsMountPointFactory.getRoot());
+            VfsRootResolver.resolveRoot(vfsMountPointFactory.getRoot());
         } catch (FileSystemException e) {
             logger.warn("VFS mount point " +  vfsMountPointFactory.getName() + " has validation problem "  + e.getMessage());
             return false;

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/factory/VFSMountPointFactoryHandler.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/factory/VFSMountPointFactoryHandler.java
@@ -16,7 +16,6 @@
 package org.jahia.modules.external.vfs.factory;
 
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemManager;
 import org.jahia.modules.external.admin.mount.AbstractMountPointFactoryHandler;
 import org.jahia.modules.external.vfs.VfsRootResolver;
 import org.jahia.services.content.JCRCallback;
@@ -132,7 +131,7 @@ public class VFSMountPointFactoryHandler extends AbstractMountPointFactoryHandle
     private boolean validateVFS(VFSMountPointFactory vfsMountPointFactory) {
         try {
             VfsRootResolver.resolveRoot(vfsMountPointFactory.getRoot());
-        } catch (FileSystemException e) {
+        } catch (FileSystemException | RuntimeException e) {
             logger.warn("VFS mount point " +  vfsMountPointFactory.getName() + " has validation problem "  + e.getMessage());
             return false;
         }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/graphql/GqlVfsMountPointMutation.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/graphql/GqlVfsMountPointMutation.java
@@ -29,6 +29,7 @@ import org.jahia.modules.external.graphql.GqlMountPointMutation;
 import org.jahia.modules.external.service.MountPointService;
 import org.jahia.modules.external.vfs.service.VfsMountPoint;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.osgi.BundleUtils;
 
 import javax.jcr.RepositoryException;
@@ -45,6 +46,7 @@ public class GqlVfsMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Create a mounted VFS mount point node in /mounts")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public String addVfs(
             @GraphQLName("name") @GraphQLDescription("Name for the mount point") @GraphQLNonNull String name,
             @GraphQLName("mountPointRefPath") @GraphQLDescription("Target local mount point") String mountPointRefPath,
@@ -69,6 +71,7 @@ public class GqlVfsMountPointMutation {
 
     @GraphQLField
     @GraphQLDescription("Modify an existing mount point node")
+    @GraphQLRequiresPermission(value = "graphqlAdminMutation")
     public boolean modifyVfs(
             @GraphQLName("pathOrId") @GraphQLDescription("Mount point path or ID to modify") @GraphQLNonNull String pathOrId,
             @GraphQLName("name") @GraphQLDescription("Rename existing mount point") String name,

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/service/VfsMountPoint.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/service/VfsMountPoint.java
@@ -24,6 +24,7 @@
 package org.jahia.modules.external.vfs.service;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.vfs2.FileSystemException;
 import org.jahia.modules.external.vfs.VfsRootResolver;
 import org.jahia.modules.external.service.MountPoint;
 import org.jahia.services.content.decorator.JCRMountPointNode;
@@ -67,7 +68,7 @@ public class VfsMountPoint extends MountPoint {
     public boolean isValidRoot() {
         try {
             VfsRootResolver.resolveRoot(rootPath);
-        } catch (Exception e) {
+        } catch (FileSystemException | RuntimeException e) {
             logger.warn("Unable to resolve VFS root path '{}': {}", rootPath, e.getMessage());
             return false;
         }

--- a/vfs/src/main/java/org/jahia/modules/external/vfs/service/VfsMountPoint.java
+++ b/vfs/src/main/java/org/jahia/modules/external/vfs/service/VfsMountPoint.java
@@ -24,7 +24,7 @@
 package org.jahia.modules.external.vfs.service;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.vfs2.VFS;
+import org.jahia.modules.external.vfs.VfsRootResolver;
 import org.jahia.modules.external.service.MountPoint;
 import org.jahia.services.content.decorator.JCRMountPointNode;
 import org.slf4j.Logger;
@@ -66,7 +66,7 @@ public class VfsMountPoint extends MountPoint {
 
     public boolean isValidRoot() {
         try {
-            VFS.getManager().resolveFile(rootPath);
+            VfsRootResolver.resolveRoot(rootPath);
         } catch (Exception e) {
             logger.warn("Unable to resolve VFS root path '{}': {}", rootPath, e.getMessage());
             return false;

--- a/vfs/src/main/resources/META-INF/configurations/org.jahia.modules.external.vfs.cfg.disabled
+++ b/vfs/src/main/resources/META-INF/configurations/org.jahia.modules.external.vfs.cfg.disabled
@@ -1,0 +1,7 @@
+
+#### Settings for VFS mount points
+#### This file should be renamed without the .disabled suffix to take effect
+
+### URI schemes the root path of a VFS mount point may use, comma-separated.
+### The local file system is the default. Name a further scheme here when a mount point needs it.
+# vfsMountPoint.allowedSchemes=file

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -2,13 +2,21 @@ package org.jahia.modules.external.vfs;
 
 import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.After;
 import org.junit.Test;
 
 import javax.jcr.RepositoryException;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -148,6 +156,91 @@ public final class VFSDataSourceTest {
             fail("Expected the name outside the root to be refused");
         } catch (FileSystemException e) {
             assertNotNull(e.getMessage());
+        }
+    }
+
+    /**
+     * A mount point on hold is asked for its root by every lookup that reaches it, and finding out that a location
+     * does not answer costs a connection attempt made while holding the instance. The attempts are bounded by the
+     * window, whatever the lookups do, and the failure is reported once rather than once per attempt.
+     */
+    @Test
+    public void aRootThatCannotBeTakenIsTakenAgainOncePerWindow() {
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("sftp"));
+        List<LogEvent> attempts = attemptsWhile(() -> {
+            dataSource.setRoot(LOCAL_DIRECTORY);
+            for (int lookup = 0; lookup < 5; lookup++) {
+                assertFalse(dataSource.itemExists("/"));
+            }
+        });
+
+        assertEquals("the attempts six lookups made: " + levelsOf(attempts), 1, attempts.size());
+        assertEquals(Level.WARN, attempts.get(0).getLevel());
+    }
+
+    /** Once the window has passed the root is taken again, and the failure it answers with is already reported. */
+    @Test
+    public void aRootIsTakenAgainOnceTheWindowHasPassed() {
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("sftp"));
+        List<LogEvent> attempts = attemptsWhile(() -> {
+            dataSource.setRoot(LOCAL_DIRECTORY);
+            dataSource.retryDelayNanos = 0;
+            assertFalse(dataSource.itemExists("/"));
+        });
+
+        assertEquals("the attempts two lookups made: " + levelsOf(attempts), 2, attempts.size());
+        assertEquals(Level.WARN, attempts.get(0).getLevel());
+        // the same root failing the same way again, which the mount point has already reported
+        assertEquals(Level.DEBUG, attempts.get(1).getLevel());
+    }
+
+    /**
+     * The attempts at taking the root that were made while a body ran. Every attempt that fails reports the root it
+     * could not take, once, so those reports count the attempts; the lines a lookup writes when it finds no root are
+     * not attempts and are left out.
+     */
+    private static List<LogEvent> attemptsWhile(Runnable body) {
+        Logger dataSourceLogger = (Logger) LogManager.getLogger(VFSDataSource.class);
+        Level level = dataSourceLogger.getLevel();
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        dataSourceLogger.addAppender(appender);
+        dataSourceLogger.setLevel(Level.DEBUG);
+        try {
+            body.run();
+        } finally {
+            dataSourceLogger.removeAppender(appender);
+            dataSourceLogger.setLevel(level);
+            appender.stop();
+        }
+        List<LogEvent> attempts = new ArrayList<>();
+        for (LogEvent event : appender.events) {
+            if (event.getMessage().getFormattedMessage().startsWith("Cannot set root to ")) {
+                attempts.add(event);
+            }
+        }
+        return attempts;
+    }
+
+    private static String levelsOf(List<LogEvent> events) {
+        List<String> levels = new ArrayList<>();
+        for (LogEvent event : events) {
+            levels.add(event.getLevel() + " " + event.getMessage().getFormattedMessage());
+        }
+        return levels.toString();
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = new ArrayList<>();
+
+        private CapturingAppender() {
+            super("capturing", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
         }
     }
 

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -1,10 +1,13 @@
 package org.jahia.modules.external.vfs;
 
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
 import org.junit.After;
 import org.junit.Test;
 
 import javax.jcr.RepositoryException;
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -23,9 +26,12 @@ public final class VFSDataSourceTest {
 
     private final VFSDataSource dataSource = new VFSDataSource();
 
+    private final File outside = new File(LOCAL_DIRECTORY, "vfs-data-source-outside.txt");
+
     @After
     public void restoreDefaults() {
         VfsRootResolver.setAllowedSchemes(null);
+        assertTrue("the file the test created should be removed", !outside.exists() || outside.delete());
     }
 
     @Test
@@ -122,6 +128,27 @@ public final class VFSDataSourceTest {
         VfsRootResolver.setAllowedSchemes(Collections.singletonList("file"));
 
         assertTrue(dataSource.itemExists("/"));
+    }
+
+    /**
+     * The root of a mount point can be set again while a lookup is under way, so a name the root does not cover is
+     * answered as a lookup that fails rather than as a path that is shorter than the root it is measured against.
+     */
+    @Test
+    public void aNameTheRootDoesNotCoverIsAnsweredAsAFailedLookup() throws IOException {
+        File inner = new File(LOCAL_DIRECTORY, "vfs-data-source-root/inner");
+        assertTrue("the root the test needs should exist", inner.isDirectory() || inner.mkdirs());
+        assertTrue("the file the test needs should exist", outside.isFile() || outside.createNewFile());
+        dataSource.setRoot(inner.getAbsolutePath());
+
+        FileObject file = VfsRootResolver.resolveRoot(outside.getAbsolutePath());
+
+        try {
+            dataSource.getFileContent(file.getContent());
+            fail("Expected the name outside the root to be refused");
+        } catch (FileSystemException e) {
+            assertNotNull(e.getMessage());
+        }
     }
 
     @Test

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -1,0 +1,73 @@
+package org.jahia.modules.external.vfs;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.jcr.RepositoryException;
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit testing of {@link VFSDataSource}, on the roots it is given
+ */
+public final class VFSDataSourceTest {
+
+    private static final String LOCAL_DIRECTORY = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+
+    private final VFSDataSource dataSource = new VFSDataSource();
+
+    @After
+    public void restoreDefaults() {
+        VfsRootResolver.setAllowedSchemes(null);
+    }
+
+    @Test
+    public void aSupportedRootIsSet() {
+        dataSource.setRoot(LOCAL_DIRECTORY);
+
+        assertNotNull(dataSource.getRoot());
+        assertEquals(LOCAL_DIRECTORY, dataSource.getRootPath());
+    }
+
+    @Test
+    public void anUnsupportedRootLeavesTheDataSourceWithoutOne() {
+        dataSource.setRoot("https://example.com/");
+
+        assertEquals(null, dataSource.getRoot());
+    }
+
+    /**
+     * The repository asks a provider whether it is available by reading its root node, and reads a RepositoryException
+     * as "not available". Anything else travels out of the call that mounts it.
+     */
+    @Test
+    public void anUnsupportedRootReportsItselfThroughARepositoryException() {
+        dataSource.setRoot("https://example.com/");
+
+        try {
+            dataSource.getItemByPath("/");
+            fail("Expected the item lookup to report the root as unusable");
+        } catch (RepositoryException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void anUnsupportedRootHasNoItems() {
+        dataSource.setRoot("https://example.com/");
+
+        assertFalse(dataSource.itemExists("/"));
+    }
+
+    @Test
+    public void aRootSetAgainAfterAnUnsupportedOneIsUsable() {
+        dataSource.setRoot("https://example.com/");
+        dataSource.setRoot(LOCAL_DIRECTORY);
+
+        assertNotNull(dataSource.getRoot());
+    }
+}

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 
 import javax.jcr.RepositoryException;
 import java.io.File;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -61,6 +63,21 @@ public final class VFSDataSourceTest {
         dataSource.setRoot("https://example.com/");
 
         assertFalse(dataSource.itemExists("/"));
+    }
+
+    /**
+     * The repository asks the same instance again, so a root refused when the mount point was mounted has to become
+     * usable once the schemes it names are allowed, without the mount point being mounted again.
+     */
+    @Test
+    public void aRootRefusedByTheConfiguredSetIsTakenAgainOnceItIsAllowed() {
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("sftp"));
+        dataSource.setRoot(LOCAL_DIRECTORY);
+        assertFalse(dataSource.itemExists("/"));
+
+        VfsRootResolver.setAllowedSchemes(null);
+
+        assertTrue(dataSource.itemExists("/"));
     }
 
     @Test

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -1,6 +1,6 @@
 package org.jahia.modules.external.vfs;
 
-import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileSystemException;
 import org.junit.After;
 import org.junit.Test;
@@ -141,10 +141,10 @@ public final class VFSDataSourceTest {
         assertTrue("the file the test needs should exist", outside.isFile() || outside.createNewFile());
         dataSource.setRoot(inner.getAbsolutePath());
 
-        FileObject file = VfsRootResolver.resolveRoot(outside.getAbsolutePath());
+        FileContent content = VfsRootResolver.resolveRoot(outside.getAbsolutePath()).getContent();
 
         try {
-            dataSource.getFileContent(file.getContent());
+            dataSource.getFileContent(content);
             fail("Expected the name outside the root to be refused");
         } catch (FileSystemException e) {
             assertNotNull(e.getMessage());

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VFSDataSourceTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,11 +36,30 @@ public final class VFSDataSourceTest {
         assertEquals(LOCAL_DIRECTORY, dataSource.getRootPath());
     }
 
+    /**
+     * A lookup reads the root, the path it starts at and the manager that resolved it, so a reader must never see one
+     * of them without the others.
+     */
+    @Test
+    public void aRootAndWhatIsDerivedFromItAreSetAndClearedTogether() {
+        dataSource.setRoot(LOCAL_DIRECTORY);
+
+        assertNotNull(dataSource.getRoot());
+        assertNotNull(dataSource.getRootPath());
+        assertNotNull(dataSource.getManager());
+
+        dataSource.setRoot("https://example.com/");
+
+        assertNull(dataSource.getRoot());
+        assertNull(dataSource.getRootPath());
+        assertNull(dataSource.getManager());
+    }
+
     @Test
     public void anUnsupportedRootLeavesTheDataSourceWithoutOne() {
         dataSource.setRoot("https://example.com/");
 
-        assertEquals(null, dataSource.getRoot());
+        assertNull(dataSource.getRoot());
     }
 
     /**
@@ -76,6 +96,30 @@ public final class VFSDataSourceTest {
         assertFalse(dataSource.itemExists("/"));
 
         VfsRootResolver.setAllowedSchemes(null);
+
+        assertTrue(dataSource.itemExists("/"));
+    }
+
+    /**
+     * The set a root was taken under is the set it goes on being served under, so narrowing the configuration stops a
+     * mount point whose root it no longer allows, the way widening it starts one.
+     */
+    @Test
+    public void aRootIsRefusedOnceTheConfiguredSetStopsAllowingIt() {
+        dataSource.setRoot(LOCAL_DIRECTORY);
+        assertTrue(dataSource.itemExists("/"));
+
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("sftp"));
+
+        assertFalse(dataSource.itemExists("/"));
+    }
+
+    /** Reading the set again must not cost the mount point its root when the set has not changed. */
+    @Test
+    public void aRootSurvivesTheSameSetBeingConfiguredAgain() {
+        dataSource.setRoot(LOCAL_DIRECTORY);
+
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("file"));
 
         assertTrue(dataSource.itemExists("/"));
     }

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
@@ -116,6 +116,25 @@ public final class VfsRootResolverTest {
     }
 
     @Test
+    public void aLayeredRootIsRefusedWhenTheSchemeUnderneathIsNotAllowed() {
+        VfsRootResolver.setAllowedSchemes(Arrays.asList("file", "gz"));
+
+        // a layer reaches whatever the layer below it names, so the set has to answer for each of them
+        assertSchemeRefused("gz:http://localhost/", "http");
+        assertSchemeRefused("gz:https://example.com/", "https");
+        // the outermost layer the set does not name is the one reported
+        assertSchemeRefused("tar:gz:http://localhost/a.tgz", "tar");
+    }
+
+    @Test
+    public void aLayeredRootOverTheLocalFilesystemIsAllowedWhenBothSchemesAre() throws FileSystemException {
+        VfsRootResolver.setAllowedSchemes(Arrays.asList("file", "gz"));
+
+        VfsRootResolver.checkSchemeAllowed("gz:file:///data/archive.gz");
+        VfsRootResolver.checkSchemeAllowed("gz:/data/archive.gz");
+    }
+
+    @Test
     public void aReadableSchemeSurvivesAlongsideAnUnreadableOne() {
         VfsRootResolver.setAllowedSchemes(Arrays.asList("sftp", "not a scheme"));
 

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
@@ -1,0 +1,118 @@
+package org.jahia.modules.external.vfs;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit testing of {@link VfsRootResolver}
+ */
+public final class VfsRootResolverTest {
+
+    private static final String LOCAL_DIRECTORY = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+
+    @After
+    public void restoreDefaults() {
+        VfsRootResolver.setAllowedSchemes(null);
+    }
+
+    @Test
+    public void localSchemeIsResolved() throws FileSystemException {
+        FileObject root = VfsRootResolver.resolveRoot("file://" + LOCAL_DIRECTORY);
+
+        assertEquals(VfsRootResolver.LOCAL_SCHEME, root.getName().getScheme());
+        // the data source reads the manager back off the resolved root
+        assertNotNull(root.getFileSystem().getFileSystemManager());
+    }
+
+    @Test
+    public void pathWithoutSchemeIsResolvedAsLocal() throws FileSystemException {
+        FileObject root = VfsRootResolver.resolveRoot(LOCAL_DIRECTORY);
+        assertEquals(VfsRootResolver.LOCAL_SCHEME, root.getName().getScheme());
+    }
+
+    @Test
+    public void remoteAndLayeredSchemesAreRefused() {
+        assertSchemeRefused("http://localhost/", "http");
+        assertSchemeRefused("https://example.com/", "https");
+        assertSchemeRefused("ftp://127.0.0.1/", "ftp");
+        assertSchemeRefused("sftp://127.0.0.1/", "sftp");
+        assertSchemeRefused("smb://host/share", "smb");
+        assertSchemeRefused("res:some/resource", "res");
+        assertSchemeRefused("jar:file:///tmp/a.jar", "jar");
+        assertSchemeRefused("zip:file:///tmp/a.zip", "zip");
+        assertSchemeRefused("tar:gz:http://127.0.0.1/a.tgz", "tar");
+    }
+
+    @Test
+    public void schemeIsMatchedRegardlessOfCase() {
+        assertSchemeRefused("HTTPS://example.com/", "https");
+    }
+
+    @Test
+    public void singleLetterPrefixIsAPathNotAScheme() throws FileSystemException {
+        // a Windows drive must not read as a URI scheme; resolving it is the local provider's business
+        VfsRootResolver.checkSchemeAllowed("d:/pdf-files");
+    }
+
+    @Test
+    public void blankRootIsRefused() {
+        assertRefused(null);
+        assertRefused("");
+        assertRefused("   ");
+    }
+
+    @Test
+    public void defaultAllowedSchemesAreTheLocalFilesystemAlone() {
+        assertEquals(Collections.singleton(VfsRootResolver.LOCAL_SCHEME), VfsRootResolver.getAllowedSchemes());
+    }
+
+    @Test
+    public void configuredSchemesAreTrimmedLoweredAndReplaceTheDefault() throws FileSystemException {
+        VfsRootResolver.setAllowedSchemes(Arrays.asList(" FILE ", "sftp"));
+
+        assertEquals(new LinkedHashSet<>(Arrays.asList("file", "sftp")), VfsRootResolver.getAllowedSchemes());
+        VfsRootResolver.checkSchemeAllowed("sftp://127.0.0.1/");
+        VfsRootResolver.checkSchemeAllowed("file://" + LOCAL_DIRECTORY);
+        // widening the set adds only what was configured
+        assertSchemeRefused("https://example.com/", "https");
+    }
+
+    @Test
+    public void emptyConfigurationRestoresTheLocalFilesystem() {
+        VfsRootResolver.setAllowedSchemes(Collections.emptyList());
+
+        assertEquals(Collections.singleton(VfsRootResolver.LOCAL_SCHEME), VfsRootResolver.getAllowedSchemes());
+    }
+
+    private static void assertSchemeRefused(String rootPath, String expectedScheme) {
+        String message = assertRefused(rootPath);
+        assertTrue("Expected the message to name the scheme " + expectedScheme + ", got: " + message,
+                message.contains('"' + expectedScheme + '"'));
+        // Apache VFS reads a FileSystemException message as a resource-bundle key; the message must survive that
+        assertFalse("The message was rendered as a VFS message code: " + message,
+                message.contains("Unknown message with code"));
+    }
+
+    private static String assertRefused(String rootPath) {
+        try {
+            VfsRootResolver.checkSchemeAllowed(rootPath);
+        } catch (FileSystemException e) {
+            return e.getMessage();
+        }
+        fail("Expected the root path to be refused: " + rootPath);
+        return null;
+    }
+}

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
@@ -97,6 +97,22 @@ public final class VfsRootResolverTest {
         assertEquals(Collections.singleton(VfsRootResolver.LOCAL_SCHEME), VfsRootResolver.getAllowedSchemes());
     }
 
+    @Test
+    public void aConfiguredValueThatIsNotASchemeNameRestoresTheLocalFilesystem() {
+        // the set also decides which providers the resolving manager carries, so an unreadable set must not widen it
+        VfsRootResolver.setAllowedSchemes(Arrays.asList("[Ljava.lang.String;@1f2a3b", "file,https", "http://x"));
+
+        assertEquals(Collections.singleton(VfsRootResolver.LOCAL_SCHEME), VfsRootResolver.getAllowedSchemes());
+        assertSchemeRefused("https://example.com/", "https");
+    }
+
+    @Test
+    public void aReadableSchemeSurvivesAlongsideAnUnreadableOne() {
+        VfsRootResolver.setAllowedSchemes(Arrays.asList("sftp", "not a scheme"));
+
+        assertEquals(Collections.singleton("sftp"), VfsRootResolver.getAllowedSchemes());
+    }
+
     private static void assertSchemeRefused(String rootPath, String expectedScheme) {
         String message = assertRefused(rootPath);
         assertTrue("Expected the message to name the scheme " + expectedScheme + ", got: " + message,

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
@@ -135,6 +135,23 @@ public final class VfsRootResolverTest {
     }
 
     @Test
+    public void aLayeredRootOverAPathIsRefusedWhenTheLocalFilesystemIsNotAllowed() {
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("gz"));
+
+        // the layer under gz: is a path, which names the same place as file:// and is answered for alike
+        assertSchemeRefused("gz:/data/archive.gz", VfsRootResolver.LOCAL_SCHEME);
+        assertSchemeRefused("gz:file:///data/archive.gz", VfsRootResolver.LOCAL_SCHEME);
+        assertSchemeRefused("/data/archive.gz", VfsRootResolver.LOCAL_SCHEME);
+    }
+
+    @Test
+    public void aLocalRootThatCarriesAnAuthorityIsStillLocal() throws FileSystemException {
+        // file://d:/pdf-files is the form the documentation gives for a Windows drive, and it names file: alone
+        VfsRootResolver.checkSchemeAllowed("file://d:/pdf-files");
+        VfsRootResolver.checkSchemeAllowed("//data/files");
+    }
+
+    @Test
     public void aReadableSchemeSurvivesAlongsideAnUnreadableOne() {
         VfsRootResolver.setAllowedSchemes(Arrays.asList("sftp", "not a scheme"));
 

--- a/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
+++ b/vfs/src/test/java/org/jahia/modules/external/vfs/VfsRootResolverTest.java
@@ -107,6 +107,15 @@ public final class VfsRootResolverTest {
     }
 
     @Test
+    public void aPathWithoutASchemeIsRefusedWhenTheLocalFilesystemIsNotAllowed() {
+        VfsRootResolver.setAllowedSchemes(Collections.singletonList("sftp"));
+
+        // a plain path and a file: URI name the same place, so the allowed set answers for both alike
+        assertSchemeRefused("/data/files", VfsRootResolver.LOCAL_SCHEME);
+        assertSchemeRefused("file:///data/files", VfsRootResolver.LOCAL_SCHEME);
+    }
+
+    @Test
     public void aReadableSchemeSurvivesAlongsideAnUnreadableOne() {
         VfsRootResolver.setAllowedSchemes(Arrays.asList("sftp", "not a scheme"));
 


### PR DESCRIPTION
## Summary

The root path of a VFS mount point is resolved against the local file system. A root naming any other URI scheme is refused when the mount point is created or modified, and a mount point already carrying one is left unavailable when it is mounted, so the root a mount point ends up serving is the one that was accepted.

Which schemes a root may use is configurable, and defaults to the local file system alone.

## Change

`VfsRootResolver` resolves every `j:rootPath` value in the module. It owns an Apache VFS `FileSystemManager` carrying the local file provider, and it checks the root's scheme against the allowed set before resolving. The three places that turned a root into a `FileObject` now call it:

- `VFSDataSource.setRoot` — the mount itself, reached from `VFSProviderFactory.mountProvider`; a root it cannot use leaves the data source without one, and the reason travels with every lookup that then reports it
- `VfsMountPoint.isValidRoot` — validation behind `addVfs` / `modifyVfs`
- `VFSMountPointFactoryHandler.validateVFS` — validation behind the mount-points administration screen

A root is accepted as a plain file system path (`/data/files`), or with the `file` scheme (`file:///data/files`, `file://d:/data`). The allowed set is read from the `org.jahia.modules.external.vfs` configuration, key `vfsMountPoint.allowedSchemes`; `org.jahia.modules.external.vfs.cfg.disabled` documents it. With no configuration present, the module keeps its own default.

`VfsRootNotAllowedException` carries the reason as plain text. `FileSystemException` reads its message as a key into Apache VFS's resource bundle, so a message that is not a key there reaches the log as `Unknown message with code "..."`.

A refused root leaves the data source without one and reports that through its accessors, rather than reporting it to the caller that mounts it. The repository mounts each mount point in turn and reads a `RepositoryException` as "this one is not available", which is what puts the mount point in the waiting state and hands it to the periodic checker; the mount points after it keep being mounted. `VFSProviderFactory.mountProvider` also converts an unchecked exception to a `RepositoryException`, so whatever else happens inside it stays within what the repository handles.

Every field that reads or writes a mount point now states the permission it requires, with a `@GraphQLRequiresPermission` annotation of its own, rather than relying on the field above it: `mountPoint()` on `JahiaAdminQueryExtension` and `JahiaAdminMutationExtension`, the two fields of `GqlMountPointQuery`, the four of `GqlMountPointMutation`, and the two of `GqlVfsMountPointMutation`. Permissions are keyed by type and field, and the current and the deprecated route resolve to the same type, so one annotation per field answers for both routes. Every one of these fields already required the permission it now names through the field above it, so no caller's reach changes where the permissions are left as they ship. An installation that has set one of the `permission.Gql*MountPoint*` keys in `org.jahia.modules.graphql.provider` is the exception: an annotation is laid over a configured permission, so a key that narrowed one of these fields stops applying, and one that widened it for automation stops working. The changelog entry names the permissions to grant instead.

## Verification

Built against Jahia 8.2.4.0 and deployed to a local instance; the module's three bundles reach ACTIVE. That exercises the package imports the module gains: `org.apache.commons.vfs2.cache`, `.impl` and `.provider.local` in the resolver, all exported by the platform at 2.10.0, and `org.jahia.modules.graphql.provider.dxm.security` in the `vfs` bundle, which imports it for the first time here.

**Unit** — `VfsRootResolverTest`, 16 cases: the accepted forms resolve as local, each refused scheme is named in the message, the scheme match is case-insensitive, a single-letter prefix stays a path rather than reading as a scheme, and the configured set is trimmed, lower-cased and restored to the default when empty. A layered root is answered for at every layer, so a set naming `gz` and `file` accepts `gz:file:///data` and `gz:/data` and refuses `gz:http://host/` on the layer underneath, naming the outermost layer the set does not name. A root carrying an authority stays local, which is the form the documentation gives for a Windows drive.

`VFSDataSourceTest`, 12 cases, covers the root a data source is given: a supported one is set, an unsupported one leaves it without a root, and it reports that through a `RepositoryException` and through `itemExists`, which is what the repository reads as "not available". A root and the path and manager derived from it are set and cleared together. A root the configured set stops naming stops serving, and one it starts naming serves again, neither needing the instance restarted. A mount point on hold bounds the attempts it makes at taking its root: six lookups inside the window make one attempt and report it once, and a lookup after the window makes a second. A name the root's own path does not cover is answered as a lookup that fails.

**End to end** — a new `vfs-mount-root.cy.ts` spec, 10 cases: a plain path and a `file` root are accepted and serve their content; `http`, `https`, `zip:` and `jar:` roots are refused on creation, with the reported error naming the root; a refused change leaves the previous root in place; and a mount point whose stored root is not supported leaves the other mount points serving, while it is itself reported as not mounted. Run against a build without this change, its refusal cases fail and its acceptance cases pass, so each refusal case tests the behaviour it names.

A second spec, `vfs-mount-root-schemes.cy.ts`, 6 cases, covers the configured set end to end: it sets the set through the configuration service, the way the jcontent suite does, and reads the answer back from the mount point API — a scheme the set does not name is refused, one it names is accepted, the local file system keeps working beside it, and dropping it refuses the scheme again. A configured layered scheme over a root the set does not name is refused, and a mount point already mounted stops serving when the set stops naming the scheme of its root and serves again when the set names it. Its probe scheme reads a local file, so nothing in either spec reaches off the machine. The set is instance state, so the spec clears it before the suite as well as after it.

The repository's own startup loop over stored mount points is not reachable from the end-to-end suite, which cannot restart a bundle. It was exercised by hand instead, against an instance carrying one mount point whose stored root is no longer supported alongside one that is: the unsupported one goes to `waiting`, the other stays `mounted` and serves its content, and nothing unchecked reaches the repository.

**No regression** — the existing suite was run twice on the same instance, once with this change and once without it, and the set of failing cases is identical. Over `api`, `admin-mountPoints`, `identifier-cache` and `vfs`, 29 of 43 cases fail in both runs, case for case, with none new and none recovered. `api.cy.ts` is the one that matters most, because it exercises the deprecated `admin.mountPoint` route the annotations now name a permission on: 7 failing before, the same 7 after. Those 29 are what that instance lacks, not what the change does — `/sites` on it holds only `systemsite`, so every case needing another site or the jContent UI fails there. CI provisions that site. No existing spec or fixture is modified.

**Release** — the changelog fragment declares `patch` deliberately, so that the change is owed to a maintenance release, even though it can require an operator to change a configuration. The fragment carries the detail such a change needs: who is affected, how to tell, and what to set.

## Note

A local file system root reaches any file the Jahia process can read, which is what a VFS mount point is for. Confining a root to a subtree is not part of this change.

